### PR TITLE
Enhance reserve page responsiveness

### DIFF
--- a/app/reserve/page.tsx
+++ b/app/reserve/page.tsx
@@ -93,7 +93,7 @@ export default function ReservePage() {
   return (
     <div className="space-y-6">
       {/* Header Section */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+      <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
         <div className="space-y-2">
           <div className="flex items-center gap-3">
             <h1 className="text-xl sm:text-2xl font-bold text-white">
@@ -120,10 +120,10 @@ export default function ReservePage() {
             . Currently tracking $SOL, $PYTH, $USDC & $USDT only.
           </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-col md:flex-row items-start md:items-center gap-3 w-full md:w-auto">
           <Badge
             variant="outline"
-            className="text-gray-400 border-gray-600 text-sm"
+            className="text-gray-400 border-gray-600 text-xs sm:text-sm"
           >
             {swapTransactions.length} Recent Swaps
           </Badge>
@@ -131,7 +131,7 @@ export default function ReservePage() {
             onClick={fetchReserveData}
             disabled={loading}
             size="sm"
-            className="bg-purple-600 hover:bg-purple-700 text-white flex items-center gap-2"
+            className="bg-purple-600 hover:bg-purple-700 text-white flex items-center gap-2 w-fit justify-center self-start"
           >
             <RefreshCw
               className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
@@ -146,7 +146,7 @@ export default function ReservePage() {
 
       {/* Account Details */}
       <div className="space-y-6">
-        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+        <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
           <h2 className="text-xl sm:text-2xl font-bold text-white">
             Reserve Accounts
           </h2>
@@ -167,7 +167,7 @@ export default function ReservePage() {
 
       {/* Swap Transactions */}
       <div className="space-y-6">
-        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+        <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
           <h2 className="text-xl sm:text-2xl font-bold text-white">
             Recent Swap Operations
           </h2>
@@ -209,4 +209,3 @@ export default function ReservePage() {
     </div>
   );
 }
-

--- a/components/reserve-summary.tsx
+++ b/components/reserve-summary.tsx
@@ -37,7 +37,7 @@ export function ReserveSummary({ reserveSummary }: ReserveSummaryProps) {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+      <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
         <h2 className="text-xl sm:text-2xl font-bold text-white">
           Pyth Reserve Summary
         </h2>
@@ -51,7 +51,7 @@ export function ReserveSummary({ reserveSummary }: ReserveSummaryProps) {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
         {/* Total Reserve Value */}
         <Card className="bg-[#2a2f3e] border-gray-700 hover:border-purple-400 hover:shadow-lg hover:shadow-purple-500/30 transition-all duration-300 group">
           <CardContent className="p-4 sm:p-6">
@@ -100,4 +100,3 @@ export function ReserveSummary({ reserveSummary }: ReserveSummaryProps) {
     </div>
   );
 }
-

--- a/components/swap-transactions.tsx
+++ b/components/swap-transactions.tsx
@@ -75,7 +75,7 @@ export function SwapTransactions({ transactions }: SwapTransactionsProps) {
       </CardHeader>
           <CardContent>
             {/* Table Header - Desktop Only */}
-            <div className="hidden sm:flex items-center justify-evenly gap-4 pb-3 mb-3 border-b border-gray-700 px-3">
+            <div className="hidden md:flex items-center justify-evenly gap-4 pb-3 mb-3 border-b border-gray-700 px-3">
               <div className="flex items-center gap-2 flex-1 min-w-0">
                 <div className="w-6 h-6 flex-shrink-0"></div>
                 <div className="min-w-0">
@@ -110,7 +110,7 @@ export function SwapTransactions({ transactions }: SwapTransactionsProps) {
                   className="block p-3 bg-gray-800/30 rounded-lg hover:bg-gray-800/50 transition-all duration-200 ease-in-out hover:scale-[1.02] hover:shadow-md hover:shadow-purple-500/20 border border-transparent hover:border-purple-500/30"
                 >
               {/* Mobile Layout */}
-              <div className="sm:hidden space-y-3">
+              <div className="md:hidden space-y-3">
                 <div className="flex items-center justify-between gap-2">
                   <div className="flex items-center gap-2 flex-1 min-w-0">
                     <div className="w-6 h-6 flex items-center justify-center flex-shrink-0">
@@ -179,7 +179,7 @@ export function SwapTransactions({ transactions }: SwapTransactionsProps) {
               </div>
 
               {/* Desktop Layout */}
-              <div className="hidden sm:flex items-center justify-evenly gap-4">
+              <div className="hidden md:flex items-center justify-evenly gap-4">
                 {/* Input Token */}
                 <div className="flex items-center gap-2 flex-1 min-w-0">
                   <div className="w-6 h-6 flex items-center justify-center flex-shrink-0">


### PR DESCRIPTION
Summary
- align `reserve` page header, account, and swap sections with the md breakpoint so mobile layout matches other pages
- adjust badge/refresh button layout, summary grid, and swap transaction tables to add intermediate breakpoints and compact controls
- limit wide refresh button and ensure card grids stack consistently on smaller viewports

Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI/layout adjustments (Tailwind breakpoint tweaks) with no changes to data fetching or business logic; risk is limited to potential minor visual regressions at specific viewport widths.
> 
> **Overview**
> Improves `reserve` page responsiveness by shifting key layouts (header, account section, swap section) from `sm` to `md` breakpoints so mobile/tablet behavior matches the rest of the app.
> 
> Tightens small-screen UI by stacking the swaps badge/refresh button, making the refresh control compact (`w-fit`), updating the summary card grid to use `md` two-column layout, and switching the swap transactions table header/desktop layout to `md` (with `md:hidden` mobile rows).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b6087bab98354dcb0a38c44d81763f22bb00365. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated responsive breakpoints across Reserve page components for consistent layout behavior.
  * Adjusted element widths, alignments, and typography sizing for better text wrapping and spacing.
  * Modified layout stacking and grid column configurations across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->