### PR TITLE
Add pageable swap transactions with throttle message

### DIFF
--- a/action/swapTransactionsActions.ts
+++ b/action/swapTransactionsActions.ts
@@ -203,17 +203,87 @@ export async function getSwapTransactionsPage(
     let connection = createConnection(0);
     const councilOpsAddress = new PublicKey(PYTHIAN_COUNCIL_OPS_MULTISIG_ADDRESS);
 
+    const targetCount = page * pageSize;
+    const batchLimit = 50;
+    let beforeSignature: string | undefined;
+    let collected: SwapTransaction[] = [];
+    let hasMore = false;
+
     // Try with fallback endpoints
-    let signatures: any[] = [];
     for (let i = 0; i < RPC_ENDPOINTS.length; i++) {
       try {
         connection = createConnection(i);
-        // Fetch recent signatures (last 100 transactions)
-        const signaturesLimit = Math.min(page * pageSize + 1, 1000);
-        const response = await connection.getSignaturesForAddress(councilOpsAddress, {
-          limit: signaturesLimit,
-        });
-        signatures = response;
+
+        while (collected.length < targetCount) {
+          const response = await connection.getSignaturesForAddress(councilOpsAddress, {
+            limit: batchLimit,
+            before: beforeSignature,
+          });
+
+          if (response.length === 0) {
+            hasMore = false;
+            break;
+          }
+
+          beforeSignature = response[response.length - 1].signature;
+          hasMore = response.length === batchLimit;
+
+          const signatureStrings = response.map((sig) => sig.signature);
+          const parsed = await connection.getParsedTransactions(signatureStrings, {
+            maxSupportedTransactionVersion: 0,
+          });
+
+          const parsedTransactions = parsed
+            .map((parsedTx, index) => {
+              const sig = response[index];
+              const tx = parseSwapTransactionFromParsed(sig.signature, parsedTx);
+              if (!tx) {
+                return null;
+              }
+
+              let blockTime: number | null = null;
+              const now = Math.floor(Date.now() / 1000);
+              const oneYearAgo = now - 365 * 24 * 60 * 60;
+
+              if (sig.blockTime !== null && sig.blockTime !== undefined && sig.blockTime > 0) {
+                if (sig.blockTime <= now && sig.blockTime >= oneYearAgo) {
+                  blockTime = sig.blockTime;
+                }
+              }
+
+              if (!blockTime && tx.timestamp && tx.timestamp > 0) {
+                if (tx.timestamp <= now && tx.timestamp >= oneYearAgo) {
+                  blockTime = tx.timestamp;
+                }
+              }
+
+              if (!blockTime || blockTime <= 0) {
+                return null;
+              }
+
+              const transactionDate = new Date(blockTime * 1000);
+              const formattedDate = new Intl.DateTimeFormat("en-US", {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+                hour12: true,
+                timeZone: "UTC",
+                timeZoneName: "short",
+              }).format(transactionDate);
+
+              return {
+                ...tx,
+                timestamp: blockTime,
+                date: formattedDate,
+              };
+            })
+            .filter((tx): tx is SwapTransaction => tx !== null);
+
+          collected = collected.concat(parsedTransactions);
+        }
+
         break;
       } catch (error) {
         if (i === RPC_ENDPOINTS.length - 1) {
@@ -222,84 +292,15 @@ export async function getSwapTransactionsPage(
       }
     }
 
+    const sorted = collected.sort((a, b) => b.timestamp - a.timestamp);
     const pageStart = (page - 1) * pageSize;
     const pageEnd = pageStart + pageSize;
-    const hasMore = signatures.length > pageEnd;
-    const pageSignatures = signatures.slice(pageStart, pageEnd);
-
-    if (pageSignatures.length === 0) {
-      return {
-        transactions: [],
-        hasMore: false,
-        page,
-        pageSize,
-      };
-    }
-
-    // Parse transactions in a single batch RPC for the requested page only
-    const signatureStrings = pageSignatures.map((sig) => sig.signature);
-    const parsed = await connection.getParsedTransactions(signatureStrings, {
-      maxSupportedTransactionVersion: 0,
-    });
-
-    const parsedTransactions = parsed.map((parsedTx, index) => {
-      const sig = pageSignatures[index];
-      const tx = parseSwapTransactionFromParsed(sig.signature, parsedTx);
-      if (!tx) {
-        return null;
-      }
-
-      let blockTime: number | null = null;
-      const now = Math.floor(Date.now() / 1000);
-      const oneYearAgo = now - 365 * 24 * 60 * 60;
-
-      // Priority 1: Use signature blockTime if present and valid (no extra RPC)
-      if (sig.blockTime !== null && sig.blockTime !== undefined && sig.blockTime > 0) {
-        if (sig.blockTime <= now && sig.blockTime >= oneYearAgo) {
-          blockTime = sig.blockTime;
-        }
-      }
-
-      // Priority 2: Use transaction blockTime if valid
-      if (!blockTime && tx.timestamp && tx.timestamp > 0) {
-        if (tx.timestamp <= now && tx.timestamp >= oneYearAgo) {
-          blockTime = tx.timestamp;
-        }
-      }
-
-      if (!blockTime || blockTime <= 0) {
-        return null;
-      }
-
-      const transactionDate = new Date(blockTime * 1000);
-      const formattedDate = new Intl.DateTimeFormat("en-US", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: true,
-        timeZone: "UTC",
-        timeZoneName: "short",
-      }).format(transactionDate);
-
-      return {
-        ...tx,
-        timestamp: blockTime,
-        date: formattedDate,
-      };
-    });
-
-    // Filter out null results, sort by timestamp (descending - most recent first)
-    // Then take the 10 most recent
-    const swapTransactions = parsedTransactions
-      .filter((tx): tx is SwapTransaction => tx !== null)
-      .sort((a, b) => b.timestamp - a.timestamp) // Descending order (most recent first)
-      .slice(0, pageSize); // Only the requested page size
+    const pageTransactions = sorted.slice(pageStart, pageEnd);
+    const hasMorePages = sorted.length > pageEnd || hasMore;
 
     return {
-      transactions: swapTransactions,
-      hasMore,
+      transactions: pageTransactions,
+      hasMore: hasMorePages,
       page,
       pageSize,
     };

--- a/app/reserve/page.tsx
+++ b/app/reserve/page.tsx
@@ -33,7 +33,7 @@ export default function ReservePage() {
   const fetchSwapPage = useCallback(
     async (page: number, force: boolean = false) => {
       const now = Date.now();
-      const remaining = 5000 - (now - swapThrottleRef.current);
+      const remaining = 10000 - (now - swapThrottleRef.current);
       if (!force && remaining > 0) {
         setSwapThrottleRemainingMs(remaining);
         return;
@@ -79,7 +79,7 @@ export default function ReservePage() {
     if (swapThrottleRemainingMs <= 0) return;
     const interval = setInterval(() => {
       const now = Date.now();
-      const remaining = 5000 - (now - swapThrottleRef.current);
+      const remaining = 10000 - (now - swapThrottleRef.current);
       setSwapThrottleRemainingMs(remaining > 0 ? remaining : 0);
     }, 200);
     return () => clearInterval(interval);

--- a/app/reserve/page.tsx
+++ b/app/reserve/page.tsx
@@ -5,7 +5,7 @@ import { ReserveSummary } from "@/components/reserve-summary";
 import { ReserveAccountCard } from "@/components/reserve-account-card";
 import { SwapTransactions } from "@/components/swap-transactions";
 import { getPythReserveSummary } from "@/action/pythReserveActions";
-import { getSwapTransactions } from "@/action/swapTransactionsActions";
+import { getSwapTransactionsPage } from "@/action/swapTransactionsActions";
 import type { PythReserveSummary, SwapTransaction } from "@/types/pythTypes";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -16,27 +16,66 @@ export default function ReservePage() {
   const [reserveSummary, setReserveSummary] =
     useState<PythReserveSummary | null>(null);
   const [swapTransactions, setSwapTransactions] = useState<SwapTransaction[]>([]);
+  const [swapPage, setSwapPage] = useState(1);
+  const [swapPageSize] = useState(10);
+  const [swapHasMore, setSwapHasMore] = useState(false);
+  const [swapLoading, setSwapLoading] = useState(false);
+  const swapCacheRef = useRef(new Map<number, SwapTransaction[]>());
+  const swapHasMoreCacheRef = useRef(new Map<number, boolean>());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const hasFetchedRef = useRef(false);
-  const isFetchingRef = useRef(false);
+  const isFetchingReserveRef = useRef(false);
+  const isFetchingSwapsRef = useRef(false);
+
+  const fetchSwapPage = useCallback(
+    async (page: number, force: boolean = false) => {
+      if (!force && swapCacheRef.current.has(page)) {
+        setSwapTransactions(swapCacheRef.current.get(page) || []);
+        setSwapHasMore(swapHasMoreCacheRef.current.get(page) || false);
+        setSwapPage(page);
+        return;
+      }
+
+      if (isFetchingSwapsRef.current) {
+        return;
+      }
+
+      try {
+        isFetchingSwapsRef.current = true;
+        setSwapLoading(true);
+        setError(null);
+        const response = await getSwapTransactionsPage(page, swapPageSize);
+        swapCacheRef.current.set(page, response.transactions);
+        swapHasMoreCacheRef.current.set(page, response.hasMore);
+        setSwapTransactions(response.transactions);
+        setSwapHasMore(response.hasMore);
+        setSwapPage(page);
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error ? err.message : "Failed to fetch swap transactions";
+        setError(errorMessage);
+        console.error("Error fetching swap transactions:", err);
+      } finally {
+        setSwapLoading(false);
+        isFetchingSwapsRef.current = false;
+      }
+    },
+    [swapPageSize]
+  );
 
   const fetchReserveData = useCallback(async () => {
     // Prevent multiple simultaneous fetches
-    if (isFetchingRef.current) {
+    if (isFetchingReserveRef.current) {
       return;
     }
 
     try {
-      isFetchingRef.current = true;
+      isFetchingReserveRef.current = true;
       setLoading(true);
       setError(null);
-      const [data, swaps] = await Promise.all([
-        getPythReserveSummary(),
-        getSwapTransactions(),
-      ]);
+      const data = await getPythReserveSummary();
       setReserveSummary(data);
-      setSwapTransactions(swaps);
       hasFetchedRef.current = true;
     } catch (err) {
       const errorMessage =
@@ -45,7 +84,7 @@ export default function ReservePage() {
       console.error("Error fetching reserve summary:", err);
     } finally {
       setLoading(false);
-      isFetchingRef.current = false;
+      isFetchingReserveRef.current = false;
     }
   }, []);
 
@@ -53,6 +92,7 @@ export default function ReservePage() {
     // Only fetch on initial mount if we haven't fetched yet
     if (!hasFetchedRef.current) {
       fetchReserveData();
+      fetchSwapPage(1);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Intentionally empty - only run once on mount
@@ -128,7 +168,12 @@ export default function ReservePage() {
             {swapTransactions.length} Recent Swaps
           </Badge>
           <Button
-            onClick={fetchReserveData}
+            onClick={() => {
+              swapCacheRef.current.clear();
+              swapHasMoreCacheRef.current.clear();
+              fetchReserveData();
+              fetchSwapPage(swapPage, true);
+            }}
             disabled={loading}
             size="sm"
             className="bg-purple-600 hover:bg-purple-700 text-white flex items-center gap-2 w-fit justify-center self-start"
@@ -172,7 +217,14 @@ export default function ReservePage() {
             Recent Swap Operations
           </h2>
         </div>
-        <SwapTransactions transactions={swapTransactions} />
+        <SwapTransactions
+          transactions={swapTransactions}
+          page={swapPage}
+          pageSize={swapPageSize}
+          hasMore={swapHasMore}
+          isLoading={swapLoading}
+          onPageChange={(page) => fetchSwapPage(page)}
+        />
       </div>
 
       {/* Information Section */}

--- a/components/swap-transactions.tsx
+++ b/components/swap-transactions.tsx
@@ -313,13 +313,13 @@ export function SwapTransactions({
           <div className="flex items-center gap-2">
             {throttleActive ? (
               <div className="text-xs text-purple-300 mr-1">
-                Requests too frequent. Try again in {throttleSeconds}s
+                You can click in {throttleSeconds}s
               </div>
             ) : null}
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8 hover:bg-gray-800 hover:text-white transition-colors hover:cursor-pointer"
+              className="h-8 w-8 hover:bg-gray-800 hover:text-white transition-colors hover:cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-gray-400"
               onClick={() => onPageChange(1)}
               disabled={page === 1 || isLoading || throttleActive}
             >
@@ -328,7 +328,7 @@ export function SwapTransactions({
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8 hover:bg-gray-800 hover:text-white transition-colors hover:cursor-pointer"
+              className="h-8 w-8 hover:bg-gray-800 hover:text-white transition-colors hover:cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-gray-400"
               onClick={() => onPageChange(Math.max(1, page - 1))}
               disabled={page === 1 || isLoading || throttleActive}
             >
@@ -340,7 +340,7 @@ export function SwapTransactions({
                 variant="ghost"
                 size="icon"
                 className={cn(
-                  "h-8 w-8 text-xs",
+                  "h-8 w-8 text-xs disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-gray-400",
                   p === page
                     ? "bg-purple-600 text-white hover:bg-purple-500"
                     : "text-gray-300 hover:bg-gray-800 hover:text-white hover:cursor-pointer"
@@ -354,7 +354,7 @@ export function SwapTransactions({
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8 hover:bg-gray-800 hover:text-white transition-colors hover:cursor-pointer"
+              className="h-8 w-8 hover:bg-gray-800 hover:text-white transition-colors hover:cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-gray-400"
               onClick={() => onPageChange(page + 1)}
               disabled={!hasMore || isLoading || throttleActive}
             >

--- a/components/swap-transactions.tsx
+++ b/components/swap-transactions.tsx
@@ -13,6 +13,7 @@ interface SwapTransactionsProps {
   pageSize: number;
   hasMore: boolean;
   isLoading: boolean;
+  throttleRemainingMs: number;
   onPageChange: (page: number) => void;
 }
 
@@ -22,6 +23,7 @@ export function SwapTransactions({
   pageSize,
   hasMore,
   isLoading,
+  throttleRemainingMs,
   onPageChange,
 }: SwapTransactionsProps) {
   const formatTokenAmount = (amount: number) => {
@@ -81,6 +83,9 @@ export function SwapTransactions({
   for (let p = startPage; p <= endPage; p += 1) {
     pageNumbers.push(p);
   }
+
+  const throttleSeconds = Math.ceil(throttleRemainingMs / 1000);
+  const throttleActive = throttleRemainingMs > 0;
 
   if (transactions.length === 0) {
     return (
@@ -304,16 +309,28 @@ export function SwapTransactions({
           ))}
         </div>
         <div className="mt-4 flex items-center justify-between gap-3">
-          <div className="text-xs text-gray-400">
-            {pageSize} per page
-          </div>
+          <div className="text-xs text-gray-400">{pageSize} per page</div>
           <div className="flex items-center gap-2">
+            {throttleActive ? (
+              <div className="text-xs text-purple-300 mr-1">
+                Requests too frequent. Try again in {throttleSeconds}s
+              </div>
+            ) : null}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 hover:bg-gray-800 hover:text-white transition-colors hover:cursor-pointer"
+              onClick={() => onPageChange(1)}
+              disabled={page === 1 || isLoading || throttleActive}
+            >
+              <span className="text-xs font-semibold">«</span>
+            </Button>
             <Button
               variant="ghost"
               size="icon"
               className="h-8 w-8 hover:bg-gray-800 hover:text-white transition-colors hover:cursor-pointer"
               onClick={() => onPageChange(Math.max(1, page - 1))}
-              disabled={page === 1 || isLoading}
+              disabled={page === 1 || isLoading || throttleActive}
             >
               <ChevronLeft className="h-4 w-4" />
             </Button>
@@ -329,7 +346,7 @@ export function SwapTransactions({
                     : "text-gray-300 hover:bg-gray-800 hover:text-white hover:cursor-pointer"
                 )}
                 onClick={() => onPageChange(p)}
-                disabled={isLoading}
+                disabled={isLoading || throttleActive}
               >
                 {p}
               </Button>
@@ -339,7 +356,7 @@ export function SwapTransactions({
               size="icon"
               className="h-8 w-8 hover:bg-gray-800 hover:text-white transition-colors hover:cursor-pointer"
               onClick={() => onPageChange(page + 1)}
-              disabled={!hasMore || isLoading}
+              disabled={!hasMore || isLoading || throttleActive}
             >
               <ChevronRight className="h-4 w-4" />
             </Button>

--- a/components/top-header.tsx
+++ b/components/top-header.tsx
@@ -40,7 +40,7 @@ export function TopHeader({
           className="inline-block text-xs text-gray-400 bg-gray-800/50 px-2 py-0.5 rounded border border-gray-700 whitespace-nowrap flex-shrink-0"
           suppressHydrationWarning
         >
-          v0.1.7
+          v0.1.8
         </span>
       </div>
 


### PR DESCRIPTION
## Summary
- replace the single swap fetch with a pageable `getSwapTransactionsPage` helper and cache + throttle logic in the reserve page
- gray out pagination controls while the 10s cooldown counts down and show the "You can click in Xs" message
- expose the new pagination UI/indicator in `SwapTransactions` and bump the header version to `v0.1.8`

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: replaces swap-transaction fetching with iterative, batched pagination against Solana RPC endpoints and adds client-side caching/throttling, which could affect data completeness, ordering, and perceived freshness under rate limits.
> 
> **Overview**
> Adds pageable swap-transaction retrieval by replacing the single "last N" fetch with `getSwapTransactionsPage(page, pageSize)`, which repeatedly pulls signature batches (with `before`) and parses transactions until enough results are collected, returning `hasMore` metadata.
> 
> Updates the reserve page and `SwapTransactions` UI to support pagination, including per-page caching, a 10s click cooldown with countdown messaging, disabled/greyed pagination controls while throttled/loading, and a refresh flow that clears swap caches. Bumps the header version to `v0.1.8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de7004642b495d90ae28ccf3fd7589a48c3cde74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swap transactions now display with pagination controls (first, previous, next navigation).
  * Added loading indicators when fetching transaction data.
  * Implemented request throttling to prevent excessive data fetches.
  * Refresh button now clears cached transactions for fresh data.

* **Chores**
  * Version updated to v0.1.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->