### PR TITLE
Add cumulative PYTH purchase tracking to reserve chart

### DIFF
--- a/action/pythReserveActions.ts
+++ b/action/pythReserveActions.ts
@@ -193,6 +193,10 @@ async function getPythPrice(): Promise<number> {
   return await getPriceFromHermes(PYTH_PRICE_ID);
 }
 
+export async function getCurrentPythPriceUsd(): Promise<number> {
+  return await getPythPrice();
+}
+
 /**
  * Fetches SOL price for USD value calculations
  */
@@ -448,4 +452,3 @@ export async function getPythReserveSummary(): Promise<PythReserveSummary> {
     );
   }
 }
-

--- a/app/reserve/page.tsx
+++ b/app/reserve/page.tsx
@@ -5,7 +5,10 @@ import { ReserveSummary } from "@/components/reserve-summary";
 import { ReserveAccountCard } from "@/components/reserve-account-card";
 import { SwapTransactions } from "@/components/swap-transactions";
 import { ReservePythHoldingChart } from "@/components/reserve-pyth-holding-chart";
-import { getPythReserveSummary } from "@/action/pythReserveActions";
+import {
+  getCurrentPythPriceUsd,
+  getPythReserveSummary,
+} from "@/action/pythReserveActions";
 import { getSwapTransactionsPage } from "@/action/swapTransactionsActions";
 import { getJupiterDcaCouncilOps } from "@/action/jupiterDcaActions";
 import { getDcaCardHref } from "@/components/jupiter-dca-card";
@@ -39,6 +42,7 @@ export default function ReservePage() {
   const [swapError, setSwapError] = useState<string | null>(null);
   const [dcaStatus, setDcaStatus] =
     useState<JupiterDcaCouncilOpsStatus | null>(null);
+  const [currentPythPriceUsd, setCurrentPythPriceUsd] = useState(0);
   const [dcaLoading, setDcaLoading] = useState(true);
   const hasFetchedRef = useRef(false);
   const isFetchingReserveRef = useRef(false);
@@ -115,12 +119,14 @@ export default function ReservePage() {
       setLoading(true);
       setReserveError(null);
       setDcaLoading(true);
-      const [data, dca] = await Promise.all([
+      const [data, dca, pythPriceUsd] = await Promise.all([
         getPythReserveSummary(),
         getJupiterDcaCouncilOps(),
+        getCurrentPythPriceUsd(),
       ]);
       setReserveSummary(data);
       setDcaStatus(dca);
+      setCurrentPythPriceUsd(pythPriceUsd);
       hasFetchedRef.current = true;
     } catch (err) {
       const errorMessage =
@@ -346,7 +352,7 @@ export default function ReservePage() {
           </Card>
         </>
       ) : (
-        <ReservePythHoldingChart />
+        <ReservePythHoldingChart currentPythPriceUsd={currentPythPriceUsd} />
       )}
     </div>
   );

--- a/components/reserve-pyth-holding-chart.tsx
+++ b/components/reserve-pyth-holding-chart.tsx
@@ -20,7 +20,13 @@ import { Loader2 } from "lucide-react";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-export function ReservePythHoldingChart() {
+interface ReservePythHoldingChartProps {
+  currentPythPriceUsd: number;
+}
+
+export function ReservePythHoldingChart({
+  currentPythPriceUsd,
+}: ReservePythHoldingChartProps) {
   const rawHistory = useQuery(api.reserveSnapshots.getPythHoldingHistory, {});
 
   const chartData = useMemo(() => {
@@ -51,6 +57,10 @@ export function ReservePythHoldingChart() {
     typeof elapsedDays === "number" &&
     elapsedDays > 0
       ? Number((cumulativePurchasedSinceTracking / elapsedDays).toFixed(2))
+      : null;
+  const averageDailyPurchasedUsd =
+    averageDailyPurchased !== null && currentPythPriceUsd > 0
+      ? averageDailyPurchased * currentPythPriceUsd
       : null;
   const firstValue = chartData.at(0)?.totalPythHeld ?? null;
   const lastUpdated = chartData.at(-1)?.timestampMs;
@@ -125,9 +135,7 @@ export function ReservePythHoldingChart() {
             </div>
 
             <div>
-              <p className="text-gray-400 text-sm mb-2">
-                Cumulated $PYTH Purchased
-              </p>
+              <p className="text-gray-400 text-sm mb-2">$PYTH Purchased</p>
               <p className="text-white text-3xl font-semibold tracking-tight">
                 {cumulativePurchasedSinceTracking !== null
                   ? cumulativePurchasedSinceTracking.toLocaleString()
@@ -145,6 +153,22 @@ export function ReservePythHoldingChart() {
               <p className="text-white text-3xl font-semibold tracking-tight">
                 {averageDailyPurchased !== null
                   ? averageDailyPurchased.toLocaleString()
+                  : "-"}
+              </p>
+            </div>
+
+            <div>
+              <p className="text-gray-400 text-sm mb-2">
+                Average Daily PYTH Purchased (USD)
+              </p>
+              <p className="text-white text-3xl font-semibold tracking-tight">
+                {averageDailyPurchasedUsd !== null
+                  ? new Intl.NumberFormat("en-US", {
+                      style: "currency",
+                      currency: "USD",
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    }).format(averageDailyPurchasedUsd)
                   : "-"}
               </p>
             </div>

--- a/components/reserve-pyth-holding-chart.tsx
+++ b/components/reserve-pyth-holding-chart.tsx
@@ -121,22 +121,22 @@ export function ReservePythHoldingChart({
       : "-";
 
   return (
-    <div className="space-y-5 min-h-[calc(100vh-240px)]">
-      <Card className="bg-[#2a2f3e] border-gray-700 min-h-[calc(100vh-360px)] h-[calc(100vh-360px)] flex flex-col overflow-hidden">
-        <div className="grid h-full min-h-0 grid-cols-1 lg:grid-cols-[320px_1fr]">
+    <div className="space-y-5">
+      <Card className="bg-[#2a2f3e] border-gray-700 flex flex-col lg:min-h-[calc(100vh-360px)] lg:h-[calc(100vh-360px)] lg:overflow-hidden">
+        <div className="grid min-h-0 grid-cols-1 lg:grid-cols-[320px_1fr] lg:h-full">
           <div className="border-b lg:border-b-0 lg:border-r border-gray-700 p-6 space-y-6">
             <div>
               <p className="text-gray-400 text-sm mb-2">
                 Current Reserve Size (PYTH)
               </p>
-              <p className="text-white text-4xl font-semibold tracking-tight">
+              <p className="text-white text-3xl sm:text-4xl font-semibold tracking-tight">
                 {latestValue !== null ? latestValue.toLocaleString() : "-"}
               </p>
             </div>
 
             <div>
               <p className="text-gray-400 text-sm mb-2">$PYTH Purchased</p>
-              <p className="text-white text-3xl font-semibold tracking-tight">
+              <p className="text-white text-2xl sm:text-3xl font-semibold tracking-tight">
                 {cumulativePurchasedSinceTracking !== null
                   ? cumulativePurchasedSinceTracking.toLocaleString()
                   : "-"}
@@ -150,7 +150,7 @@ export function ReservePythHoldingChart({
               <p className="text-gray-400 text-sm mb-2">
                 Average Daily PYTH Purchased
               </p>
-              <p className="text-white text-3xl font-semibold tracking-tight">
+              <p className="text-white text-2xl sm:text-3xl font-semibold tracking-tight">
                 {averageDailyPurchased !== null
                   ? averageDailyPurchased.toLocaleString()
                   : "-"}
@@ -161,7 +161,7 @@ export function ReservePythHoldingChart({
               <p className="text-gray-400 text-sm mb-2">
                 Average Daily PYTH Purchased (USD)
               </p>
-              <p className="text-white text-3xl font-semibold tracking-tight">
+              <p className="text-white text-2xl sm:text-3xl font-semibold tracking-tight">
                 {averageDailyPurchasedUsd !== null
                   ? new Intl.NumberFormat("en-US", {
                       style: "currency",
@@ -174,10 +174,10 @@ export function ReservePythHoldingChart({
             </div>
           </div>
 
-          <div className="min-h-0 flex flex-col p-6">
+          <div className="flex min-w-0 flex-col p-6 lg:min-h-0">
             <CardHeader className="px-0 pt-0 pb-4 flex-row items-start justify-between space-y-0">
               <div>
-                <CardTitle className="text-white text-3xl">
+                <CardTitle className="text-white text-2xl sm:text-3xl">
                   Reserve PYTH Holdings over time
                 </CardTitle>
                 <CardDescription className="text-gray-400 mt-1">
@@ -188,30 +188,31 @@ export function ReservePythHoldingChart({
               </div>
             </CardHeader>
 
-            <CardContent className="px-0 pb-0 flex-1 min-h-0 flex flex-col">
+            <CardContent className="mt-2 min-w-0 px-0 pb-0 lg:mt-0 lg:flex lg:min-h-0 lg:flex-1 lg:flex-col">
               {!rawHistory ? (
-                <div className="flex-1 min-h-0 flex items-center justify-center text-gray-400">
+                <div className="h-[260px] sm:h-[320px] lg:h-full flex items-center justify-center text-gray-400">
                   <Loader2 className="h-5 w-5 animate-spin mr-2" />
                   Loading history...
                 </div>
               ) : chartData.length === 0 ? (
-                <div className="flex-1 min-h-0 flex items-center justify-center text-gray-400 text-sm">
+                <div className="h-[260px] sm:h-[320px] lg:h-full flex items-center justify-center text-gray-400 text-sm">
                   No snapshots yet. Wait for the daily cron to populate data.
                 </div>
               ) : (
-                <ChartContainer
-                  className="h-full w-full aspect-auto"
-                  config={{
-                    totalPythHeld: {
-                      label: "Current Holdings (in PYTH)",
-                      color: "#a855f7",
-                    },
-                  }}
-                >
-                  <AreaChart
-                    data={chartData}
-                    margin={{ left: 0, right: 10, top: 10, bottom: 6 }}
+                <div className="h-[260px] w-full min-w-0 sm:h-[320px] lg:h-full">
+                  <ChartContainer
+                    className="!block h-full w-full min-w-0 aspect-auto"
+                    config={{
+                      totalPythHeld: {
+                        label: "PYTH",
+                        color: "#a855f7",
+                      },
+                    }}
                   >
+                    <AreaChart
+                      data={chartData}
+                      margin={{ left: 0, right: 10, top: 10, bottom: 6 }}
+                    >
                     <defs>
                       <linearGradient
                         id="pythHoldingsFill"
@@ -275,10 +276,9 @@ export function ReservePythHoldingChart({
                     <ChartTooltip
                       content={
                         <ChartTooltipContent
-                          formatter={(value) => [
-                            `${Number(value).toLocaleString()} PYTH`,
-                            "Current Holdings",
-                          ]}
+                          formatter={(value) =>
+                            `${Number(value).toLocaleString()} PYTH`
+                          }
                           labelFormatter={(_, payload) => {
                             const timestampMs =
                               payload?.[0]?.payload?.timestampMs;
@@ -288,17 +288,18 @@ export function ReservePythHoldingChart({
                         />
                       }
                     />
-                    <Area
-                      dataKey="totalPythHeld"
-                      type="natural"
-                      stroke="var(--color-totalPythHeld)"
-                      fill="url(#pythHoldingsFill)"
-                      strokeWidth={4}
-                      dot={false}
-                      activeDot={{ r: 4, fill: "var(--color-totalPythHeld)" }}
-                    />
-                  </AreaChart>
-                </ChartContainer>
+                      <Area
+                        dataKey="totalPythHeld"
+                        type="natural"
+                        stroke="var(--color-totalPythHeld)"
+                        fill="url(#pythHoldingsFill)"
+                        strokeWidth={4}
+                        dot={false}
+                        activeDot={{ r: 4, fill: "var(--color-totalPythHeld)" }}
+                      />
+                    </AreaChart>
+                  </ChartContainer>
+                </div>
               )}
             </CardContent>
           </div>

--- a/components/reserve-pyth-holding-chart.tsx
+++ b/components/reserve-pyth-holding-chart.tsx
@@ -33,6 +33,25 @@ export function ReservePythHoldingChart() {
   }, [rawHistory]);
 
   const latestValue = chartData.at(-1)?.totalPythHeld ?? null;
+  const firstTrackedTimestampMs = chartData.at(0)?.timestampMs ?? null;
+  const latestTrackedTimestampMs = chartData.at(-1)?.timestampMs ?? null;
+  const earliestValue = chartData.at(0)?.totalPythHeld ?? null;
+  const cumulativePurchasedSinceTracking =
+    latestValue !== null && earliestValue !== null
+      ? Number((latestValue - earliestValue).toFixed(2))
+      : null;
+  const elapsedDays =
+    typeof latestTrackedTimestampMs === "number" &&
+    typeof firstTrackedTimestampMs === "number" &&
+    latestTrackedTimestampMs > firstTrackedTimestampMs
+      ? (latestTrackedTimestampMs - firstTrackedTimestampMs) / DAY_MS
+      : null;
+  const averageDailyPurchased =
+    cumulativePurchasedSinceTracking !== null &&
+    typeof elapsedDays === "number" &&
+    elapsedDays > 0
+      ? Number((cumulativePurchasedSinceTracking / elapsedDays).toFixed(2))
+      : null;
   const firstValue = chartData.at(0)?.totalPythHeld ?? null;
   const lastUpdated = chartData.at(-1)?.timestampMs;
   const spanMs =
@@ -86,6 +105,11 @@ export function ReservePythHoldingChart() {
     return ticks;
   }, [axisMode, chartData]);
 
+  const formattedTrackingStart =
+    typeof firstTrackedTimestampMs === "number"
+      ? new Date(firstTrackedTimestampMs).toLocaleDateString()
+      : "-";
+
   return (
     <div className="space-y-5 min-h-[calc(100vh-240px)]">
       <Card className="bg-[#2a2f3e] border-gray-700 min-h-[calc(100vh-360px)] h-[calc(100vh-360px)] flex flex-col overflow-hidden">
@@ -97,6 +121,31 @@ export function ReservePythHoldingChart() {
               </p>
               <p className="text-white text-4xl font-semibold tracking-tight">
                 {latestValue !== null ? latestValue.toLocaleString() : "-"}
+              </p>
+            </div>
+
+            <div>
+              <p className="text-gray-400 text-sm mb-2">
+                Cumulated $PYTH Purchased
+              </p>
+              <p className="text-white text-3xl font-semibold tracking-tight">
+                {cumulativePurchasedSinceTracking !== null
+                  ? cumulativePurchasedSinceTracking.toLocaleString()
+                  : "-"}
+              </p>
+              <p className="text-gray-500 text-xs mt-2">
+                Since tracking started: {formattedTrackingStart}
+              </p>
+            </div>
+
+            <div>
+              <p className="text-gray-400 text-sm mb-2">
+                Average Daily PYTH Purchased
+              </p>
+              <p className="text-white text-3xl font-semibold tracking-tight">
+                {averageDailyPurchased !== null
+                  ? averageDailyPurchased.toLocaleString()
+                  : "-"}
               </p>
             </div>
           </div>

--- a/components/reserve-summary.tsx
+++ b/components/reserve-summary.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import type { PythReserveSummary } from "@/types/pythTypes";
-import { TrendingUp, Coins, Building2 } from "lucide-react";
+import { TrendingUp } from "lucide-react";
 import Image from "next/image";
 
 interface ReserveSummaryProps {

--- a/types/pythTypes.ts
+++ b/types/pythTypes.ts
@@ -77,6 +77,12 @@ export type SwapTransaction = {
   explorerUrl: string;
 };
 
+export type SwapTrackingSummary = {
+  cumulativePythPurchased: number;
+  trackingStartedAt: number | null;
+  totalSwapsTracked: number;
+};
+
 /** Jupiter DCA time-based order (USDC -> PYTH relevant fields) */
 export type JupiterDcaOrder = {
   orderKey: string;


### PR DESCRIPTION
## Summary
- expose current PYTH price plus tracking summary helpers to surface USD metrics in the reserve view
- refactor swap transaction collection/tracking logic into reusable helpers and add cumulative purchase summary data
- enhance the reserve holdings chart with tracking stats, formatted chart tooltip, and clearer layout/labels

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to new Solana RPC scanning/refactoring (`collectSwapTransactions`, 5k signature cap) and additional network price fetches that could affect performance or error handling, but no auth/security or persistence changes.
> 
> **Overview**
> **Reserve history view now surfaces purchase tracking + USD metrics.** The reserve page fetches the current PYTH/USD price via a new `getCurrentPythPriceUsd` server action and passes it into `ReservePythHoldingChart`, which now computes and displays *cumulative PYTH purchased since tracking began* plus average daily purchases (token and USD), along with tooltip/label and layout tweaks.
> 
> **Swap transaction collection was refactored and extended for tracking.** A new `collectSwapTransactions` helper centralizes signature scanning/parsing with a 1-year window and a `MAX_SIGNATURE_SCAN` cap, is reused by `getSwapTransactionsPage`, and a new `getSwapTrackingSummary` API plus `SwapTrackingSummary` type were added to return cumulative purchased totals and tracking metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d5811426be9e8ff50f3d40b9a9195adcd2acb41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added swap transaction tracking summary with cumulative PYTH purchase metrics and tracking metadata
  * Enhanced reserve PYTH holding chart with new KPIs: cumulative purchases, average daily purchases, tracking start date, and USD-equivalent values
  * Integrated current PYTH price display for real-time USD value calculations

* **Chores**
  * Removed unused icon imports for code cleanup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->