### PR TITLE
Fix DCA vault balance fetch

### DIFF
--- a/types/pythTypes.ts
+++ b/types/pythTypes.ts
@@ -96,7 +96,7 @@ export type JupiterDcaOrder = {
 /** Status of Jupiter DCA usage for Council Ops (USDC -> PYTH) */
 export type JupiterDcaCouncilOpsStatus = {
   usingDca: boolean;
-  /** Total USDC balance remaining in DCA vault(s) (inDeposited - inUsed across orders) */
+  /** Total USDC balance remaining in DCA vault(s) (inDeposited - inUsed - inWithdrawn across orders) */
   usdcBalanceVault: number;
   orders: JupiterDcaOrder[];
 };


### PR DESCRIPTION
Summary
- force the Jupiter DCA council ops request to skip caching so the reserve page always pulls the latest balance
- account for withdrawn amounts when calculating the remaining USDC balance in the DCA vault
- clarify the vault balance description in the shared types

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated USDC balance calculation to correctly account for deposited, used, and withdrawn amounts when determining available balances.

* **Documentation**
  * Clarified balance computation formula in documentation to reflect the updated calculation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->