### PR TITLE
Update buyback tracking experience and bump version to 0.3.1

### DIFF
--- a/.tmp/writing-plans/SKILL.md
+++ b/.tmp/writing-plans/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: writing-plans
+description: Use when you have a spec or requirements for a multi-step task, before touching code
+---
+
+# Writing Plans
+
+## Overview
+
+Write comprehensive implementation plans assuming the engineer has zero context for our codebase and questionable taste. Document everything they need to know: which files to touch for each task, code, testing, docs they might need to check, how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.
+
+Assume they are a skilled developer, but know almost nothing about our toolset or problem domain. Assume they don't know good test design very well.
+
+**Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
+
+**Context:** This should be run in a dedicated worktree (created by brainstorming skill).
+
+**Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`
+
+## Bite-Sized Task Granularity
+
+**Each step is one action (2-5 minutes):**
+- "Write the failing test" - step
+- "Run it to make sure it fails" - step
+- "Implement the minimal code to make the test pass" - step
+- "Run the tests and make sure they pass" - step
+- "Commit" - step
+
+## Plan Document Header
+
+**Every plan MUST start with this header:**
+
+```markdown
+# [Feature Name] Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries]
+
+---
+```
+
+## Task Structure
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create: `exact/path/to/file.py`
+- Modify: `exact/path/to/existing.py:123-145`
+- Test: `tests/exact/path/to/test.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_specific_behavior():
+    result = function(input)
+    assert result == expected
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: FAIL with "function not defined"
+
+**Step 3: Write minimal implementation**
+
+```python
+def function(input):
+    return expected
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/path/test.py src/path/file.py
+git commit -m "feat: add specific feature"
+```
+````
+
+## Remember
+- Exact file paths always
+- Complete code in plan (not "add validation")
+- Exact commands with expected output
+- Reference relevant skills with @ syntax
+- DRY, YAGNI, TDD, frequent commits
+
+## Execution Handoff
+
+After saving the plan, offer execution choice:
+
+**"Plan complete and saved to `docs/plans/<filename>.md`. Two execution options:**
+
+**1. Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration
+
+**2. Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints
+
+**Which approach?"**
+
+**If Subagent-Driven chosen:**
+- **REQUIRED SUB-SKILL:** Use superpowers:subagent-driven-development
+- Stay in this session
+- Fresh subagent per task + code review
+
+**If Parallel Session chosen:**
+- Guide them to open new session in worktree
+- **REQUIRED SUB-SKILL:** New session uses superpowers:executing-plans

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Current stage: **v0.1.8 (beta)**.
   - DAO Treasury + Pythian Council Ops balances
   - USD valuation for tracked assets
   - Recent swaps into PYTH (paginated)
+  - Buyback metrics for Council Ops USDC -> PYTH execution:
+    - Total USDC spent
+    - Total PYTH bought
+    - Weighted average buy price over time (hourly snapshots)
 - Mobile-responsive layout with persistent sidebar/top header
 - Local wallet persistence (`localStorage`)
 - Installable PWA prompt + web manifest support
@@ -67,6 +71,8 @@ npm run rebuild      # npm rebuild
 
 - Wallet staking data is fetched via server actions using Pyth staking SDK + Solana RPC.
 - Reserve balances are fetched from Solana RPC for tracked reserve addresses.
+- Reserve buyback metrics are tracked in Convex via an hourly snapshot job that
+  incrementally processes new Council Ops swaps.
 - Token prices are fetched from Pyth Hermes; ticker 24h change uses CoinGecko.
 - Wallets are stored locally in browser `localStorage`.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pyth Board is a Next.js dashboard for tracking Pyth staking positions and monitoring the Pyth Strategic Reserve.
 
-Current stage: **v0.1.8 (beta)**.
+Current stage: **v0.3.1 (beta)**.
 
 ## What is live right now
 

--- a/app/reserve/page.tsx
+++ b/app/reserve/page.tsx
@@ -5,6 +5,7 @@ import { ReserveSummary } from "@/components/reserve-summary";
 import { ReserveAccountCard } from "@/components/reserve-account-card";
 import { SwapTransactions } from "@/components/swap-transactions";
 import { ReservePythHoldingChart } from "@/components/reserve-pyth-holding-chart";
+import { ReserveBuybackSummary } from "@/components/reserve-buyback-summary";
 import {
   getCurrentPythPriceUsd,
   getPythReserveSummary,
@@ -320,6 +321,8 @@ export default function ReservePage() {
             reserveSummary={reserveSummary}
             dcaVaultUsdc={dcaStatus?.usdcBalanceVault ?? 0}
           />
+
+          <ReserveBuybackSummary />
 
           <div className="space-y-5">
             <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">

--- a/components/reserve-buyback-summary.tsx
+++ b/components/reserve-buyback-summary.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Loader2 } from "lucide-react";
+import { formatPythAmount, formatUsd, formatUsdPerPyth } from "@/lib/buyback/format";
+
+export function ReserveBuybackSummary() {
+  const summary = useQuery(api.pythBuybackSnapshots.getPythBuybackSummary, {});
+
+  if (!summary) {
+    return (
+      <Card className="rounded-[28px] border-white/10 bg-[linear-gradient(148deg,rgba(255,255,255,0.06)_0%,rgba(255,255,255,0.02)_100%)] py-0 shadow-[0_20px_55px_rgba(8,5,18,0.2)]">
+        <CardContent className="flex items-center justify-center gap-2 p-6 text-[#a8a1bf]">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading buyback metrics...
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <h2 className="text-xl sm:text-2xl font-bold text-white">Buyback Metrics</h2>
+          <p className="text-xs text-[#8f88a9]">
+            {summary.trackingStartedMs
+              ? `Tracking started ${new Date(summary.trackingStartedMs).toLocaleString()}`
+              : "Tracking start pending first snapshot"}
+            {" · "}
+            {summary.lastUpdatedMs
+              ? `Updated ${new Date(summary.lastUpdatedMs).toLocaleString()}`
+              : "Waiting for first snapshot"}
+          </p>
+        </div>
+        <Badge
+          variant="outline"
+          className="rounded-xl border-white/8 bg-[#2f2942] px-3 py-1 text-xs text-[#b8b0d0]"
+        >
+          Council Ops USDC -&gt; PYTH
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3 sm:gap-5">
+        <Card className="rounded-[24px] border-white/10 bg-[linear-gradient(148deg,rgba(255,255,255,0.06)_0%,rgba(255,255,255,0.02)_100%)] py-0">
+          <CardContent className="p-5 sm:p-6">
+            <p className="text-xs text-[#a8a1bf] sm:text-sm">Total USDC Spent</p>
+            <p className="mt-2 text-2xl font-bold text-white sm:text-3xl">
+              {formatUsd(summary.totalUsdcSpent)}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-[24px] border-white/10 bg-[linear-gradient(148deg,rgba(255,255,255,0.06)_0%,rgba(255,255,255,0.02)_100%)] py-0">
+          <CardContent className="p-5 sm:p-6">
+            <p className="text-xs text-[#a8a1bf] sm:text-sm">Total PYTH Bought</p>
+            <p className="mt-2 text-2xl font-bold text-white sm:text-3xl">
+              {formatPythAmount(summary.totalPythBought)} PYTH
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-[24px] border-white/10 bg-[linear-gradient(148deg,rgba(255,255,255,0.06)_0%,rgba(255,255,255,0.02)_100%)] py-0">
+          <CardContent className="p-5 sm:p-6">
+            <p className="text-xs text-[#a8a1bf] sm:text-sm">Average Buy Price</p>
+            <p className="mt-2 text-2xl font-bold text-white sm:text-3xl">
+              {summary.avgBuyPriceUsd > 0 ? formatUsdPerPyth(summary.avgBuyPriceUsd) : "-"}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/components/reserve-buyback-summary.tsx
+++ b/components/reserve-buyback-summary.tsx
@@ -27,10 +27,6 @@ export function ReserveBuybackSummary() {
         <div className="space-y-1">
           <h2 className="text-xl sm:text-2xl font-bold text-white">Buyback Metrics</h2>
           <p className="text-xs text-[#8f88a9]">
-            {summary.trackingStartedMs
-              ? `Tracking started ${new Date(summary.trackingStartedMs).toLocaleString()}`
-              : "Tracking start pending first snapshot"}
-            {" · "}
             {summary.lastUpdatedMs
               ? `Updated ${new Date(summary.lastUpdatedMs).toLocaleString()}`
               : "Waiting for first snapshot"}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -41,7 +41,7 @@ export function Sidebar({
       {/* Mobile overlay */}
       {isMobileMenuOpen && (
         <div
-          className="md:hidden fixed inset-0 bg-black bg-opacity-50 z-40"
+          className="md:hidden fixed inset-0 bg-black/65 backdrop-blur-[2px] z-40"
           onClick={onMobileMenuToggle}
         />
       )}
@@ -52,7 +52,7 @@ export function Sidebar({
           "fixed md:relative inset-y-0 left-0 z-50 flex w-56 flex-col border-r border-white/8 bg-[#241b35] transition-transform duration-300",
           isMobileMenuOpen
             ? "translate-x-0"
-            : "-translate-x-full md:translate-x-0"
+            : "-translate-x-full md:translate-x-0",
         )}
       >
         <div className="flex h-full flex-col px-3 py-6 md:px-4">
@@ -81,7 +81,7 @@ export function Sidebar({
                     "group flex h-[52px] w-full items-center justify-start gap-3 rounded-2xl px-4 text-sm font-medium text-[#978fb1] transition-colors",
                     active
                       ? "bg-[#3a2d48] text-white shadow-[inset_0_0_0_1px_rgba(255,255,255,0.06)]"
-                      : "hover:bg-white/5 hover:text-white"
+                      : "hover:bg-white/5 hover:text-white",
                   )}
                   title={item.label}
                 >
@@ -95,7 +95,9 @@ export function Sidebar({
           <div className="mt-auto w-full space-y-4 md:space-y-3">
             <button
               className="flex w-full items-center justify-between rounded-2xl bg-[#342645] px-4 py-3 text-left text-white ring-1 ring-white/8 transition-colors hover:bg-[#3a2b4d]"
-              onClick={() => window.open("https://staking.pyth.network/", "_blank")}
+              onClick={() =>
+                window.open("https://staking.pyth.network/", "_blank")
+              }
               type="button"
               title="Start Staking"
             >
@@ -107,7 +109,10 @@ export function Sidebar({
               <button
                 className="flex h-10 w-10 items-center justify-center rounded-full text-[#978fb1] transition-colors hover:bg-white/5 hover:text-white"
                 onClick={() =>
-                  window.open("https://github.com/SCPassion/pyth-board", "_blank")
+                  window.open(
+                    "https://github.com/SCPassion/pyth-board",
+                    "_blank",
+                  )
                 }
                 type="button"
                 title="GitHub"
@@ -117,7 +122,9 @@ export function Sidebar({
               </button>
               <button
                 className="flex h-10 w-10 items-center justify-center rounded-full text-[#978fb1] transition-colors hover:bg-white/5 hover:text-white"
-                onClick={() => window.open("https://x.com/KaiCryptohk", "_blank")}
+                onClick={() =>
+                  window.open("https://x.com/KaiCryptohk", "_blank")
+                }
                 type="button"
                 title="Twitter"
               >

--- a/components/top-header.tsx
+++ b/components/top-header.tsx
@@ -52,7 +52,7 @@ export function TopHeader({
             {pageTitle}
           </p>
           <span className="hidden rounded-xl border border-white/8 bg-[#2f2942] px-2.5 py-1 text-[11px] font-semibold tracking-[0.12em] text-[#b8b0d0] sm:inline-flex">
-            0.3.0
+            0.3.1
           </span>
         </div>
       </div>

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as crons from "../crons.js";
+import type * as pythBuybackSnapshots from "../pythBuybackSnapshots.js";
 import type * as reserveSnapshots from "../reserveSnapshots.js";
 
 import type {
@@ -19,6 +20,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   crons: typeof crons;
+  pythBuybackSnapshots: typeof pythBuybackSnapshots;
   reserveSnapshots: typeof reserveSnapshots;
 }>;
 

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -10,4 +10,11 @@ crons.interval(
   {}
 );
 
+crons.interval(
+  "fetch pyth buyback metrics hourly",
+  { hours: 1 },
+  internal.pythBuybackSnapshots.runPythBuybackSnapshotJob,
+  {}
+);
+
 export default crons;

--- a/convex/pythBuybackSnapshots.ts
+++ b/convex/pythBuybackSnapshots.ts
@@ -12,6 +12,8 @@ const PYTHIAN_COUNCIL_OPS_MULTISIG_ADDRESS =
 const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 const PYTH_MINT = "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3";
 const BUYBACK_STATE_KEY = "council_ops_usdc_pyth";
+const JUPITER_RECURRING_API =
+  "https://lite-api.jup.ag/recurring/v1/getRecurringOrders";
 
 const RPC_ENDPOINTS = [
   "https://solana-mainnet.g.alchemy.com/v2/VAWGO1qOMcxkm0B9H0xUPzpNMzBnIvo8",
@@ -27,6 +29,19 @@ const CONNECTION_CONFIG = {
   httpHeaders: {
     "User-Agent": "PythBoard/1.0",
   },
+};
+
+type JupiterRecurringOrder = {
+  orderKey: string;
+  inputMint: string;
+  outputMint: string;
+  inUsed: number;
+  outReceived: number;
+};
+
+type JupiterRecurringResponse = {
+  time?: JupiterRecurringOrder[];
+  hasMoreData?: boolean;
 };
 
 function computeWeightedAverage(totalUsdcSpent: number, totalPythBought: number) {
@@ -175,12 +190,95 @@ async function fetchLatestSignature(
   return page[0]?.signature;
 }
 
+async function fetchJupiterRecurringOrders(
+  orderStatus: "active" | "history"
+): Promise<JupiterRecurringOrder[]> {
+  const orders: JupiterRecurringOrder[] = [];
+  let page = 1;
+
+  while (true) {
+    const url = new URL(JUPITER_RECURRING_API);
+    url.searchParams.set("user", PYTHIAN_COUNCIL_OPS_MULTISIG_ADDRESS);
+    url.searchParams.set("recurringType", "time");
+    url.searchParams.set("includeFailedTx", "false");
+    url.searchParams.set("orderStatus", orderStatus);
+    url.searchParams.set("page", String(page));
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        "User-Agent": "PythBoard/1.0",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Jupiter recurring API failed (${orderStatus} page ${page}): ${response.status} ${response.statusText}`
+      );
+    }
+
+    const data = (await response.json()) as JupiterRecurringResponse;
+    const timeOrders = data.time ?? [];
+    orders.push(...timeOrders);
+
+    if (!data.hasMoreData || timeOrders.length === 0) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return orders;
+}
+
+async function fetchDcaBuybackTotals(): Promise<{
+  totalUsdcSpentDca: number;
+  totalPythBoughtDca: number;
+}> {
+  const [activeOrders, historyOrders] = await Promise.all([
+    fetchJupiterRecurringOrders("active"),
+    fetchJupiterRecurringOrders("history"),
+  ]);
+
+  const orderTotals = new Map<
+    string,
+    { totalUsdcSpentDca: number; totalPythBoughtDca: number }
+  >();
+
+  for (const order of [...activeOrders, ...historyOrders]) {
+    if (order.inputMint !== USDC_MINT || order.outputMint !== PYTH_MINT) {
+      continue;
+    }
+
+    orderTotals.set(order.orderKey, {
+      totalUsdcSpentDca: Math.max(0, order.inUsed ?? 0),
+      totalPythBoughtDca: Math.max(0, order.outReceived ?? 0),
+    });
+  }
+
+  let totalUsdcSpentDca = 0;
+  let totalPythBoughtDca = 0;
+
+  for (const totals of orderTotals.values()) {
+    totalUsdcSpentDca += totals.totalUsdcSpentDca;
+    totalPythBoughtDca += totals.totalPythBoughtDca;
+  }
+
+  return {
+    totalUsdcSpentDca,
+    totalPythBoughtDca,
+  };
+}
+
 export const upsertBuybackState = internalMutation({
   args: {
     key: v.string(),
     latestProcessedSignature: v.optional(v.string()),
     totalUsdcSpent: v.number(),
     totalPythBought: v.number(),
+    totalUsdcSpentDirect: v.optional(v.number()),
+    totalPythBoughtDirect: v.optional(v.number()),
+    totalUsdcSpentDca: v.optional(v.number()),
+    totalPythBoughtDca: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const existing = await ctx.db
@@ -193,6 +291,10 @@ export const upsertBuybackState = internalMutation({
         latestProcessedSignature: args.latestProcessedSignature,
         totalUsdcSpent: args.totalUsdcSpent,
         totalPythBought: args.totalPythBought,
+        totalUsdcSpentDirect: args.totalUsdcSpentDirect,
+        totalPythBoughtDirect: args.totalPythBoughtDirect,
+        totalUsdcSpentDca: args.totalUsdcSpentDca,
+        totalPythBoughtDca: args.totalPythBoughtDca,
       });
       return existing._id;
     }
@@ -251,8 +353,21 @@ export const runPythBuybackSnapshotJob = internalAction({
         // historical backfill scans on first run.
         if (!state?.latestProcessedSignature) {
           const latestSignature = await fetchLatestSignature(connection, owner);
-          const totalUsdcSpent = state?.totalUsdcSpent ?? 0;
-          const totalPythBought = state?.totalPythBought ?? 0;
+          let totalUsdcSpentDca = state?.totalUsdcSpentDca ?? 0;
+          let totalPythBoughtDca = state?.totalPythBoughtDca ?? 0;
+
+          try {
+            const dcaTotals = await fetchDcaBuybackTotals();
+            totalUsdcSpentDca = dcaTotals.totalUsdcSpentDca;
+            totalPythBoughtDca = dcaTotals.totalPythBoughtDca;
+          } catch (error) {
+            console.warn("Failed to initialize DCA buyback totals:", error);
+          }
+
+          const totalUsdcSpentDirect = state?.totalUsdcSpentDirect ?? 0;
+          const totalPythBoughtDirect = state?.totalPythBoughtDirect ?? 0;
+          const totalUsdcSpent = totalUsdcSpentDirect + totalUsdcSpentDca;
+          const totalPythBought = totalPythBoughtDirect + totalPythBoughtDca;
           const avgBuyPriceUsd = computeWeightedAverage(
             totalUsdcSpent,
             totalPythBought
@@ -268,6 +383,10 @@ export const runPythBuybackSnapshotJob = internalAction({
               latestProcessedSignature: latestSignature,
               totalUsdcSpent,
               totalPythBought,
+              totalUsdcSpentDirect,
+              totalPythBoughtDirect,
+              totalUsdcSpentDca,
+              totalPythBoughtDca,
             }
           );
 
@@ -321,10 +440,24 @@ export const runPythBuybackSnapshotJob = internalAction({
           }
         }
 
-        const totalUsdcSpent =
-          (state?.totalUsdcSpent ?? 0) + Math.max(0, deltaUsdcSpent);
-        const totalPythBought =
-          (state?.totalPythBought ?? 0) + Math.max(0, deltaPythBought);
+        const totalUsdcSpentDirect =
+          (state?.totalUsdcSpentDirect ?? 0) + Math.max(0, deltaUsdcSpent);
+        const totalPythBoughtDirect =
+          (state?.totalPythBoughtDirect ?? 0) + Math.max(0, deltaPythBought);
+
+        let totalUsdcSpentDca = state?.totalUsdcSpentDca ?? 0;
+        let totalPythBoughtDca = state?.totalPythBoughtDca ?? 0;
+
+        try {
+          const dcaTotals = await fetchDcaBuybackTotals();
+          totalUsdcSpentDca = dcaTotals.totalUsdcSpentDca;
+          totalPythBoughtDca = dcaTotals.totalPythBoughtDca;
+        } catch (error) {
+          console.warn("Failed to refresh DCA buyback totals:", error);
+        }
+
+        const totalUsdcSpent = totalUsdcSpentDirect + totalUsdcSpentDca;
+        const totalPythBought = totalPythBoughtDirect + totalPythBoughtDca;
         const avgBuyPriceUsd = computeWeightedAverage(
           totalUsdcSpent,
           totalPythBought
@@ -345,6 +478,10 @@ export const runPythBuybackSnapshotJob = internalAction({
             latestProcessedSignature,
             totalUsdcSpent,
             totalPythBought,
+            totalUsdcSpentDirect,
+            totalPythBoughtDirect,
+            totalUsdcSpentDca,
+            totalPythBoughtDca,
           }
         );
 

--- a/convex/pythBuybackSnapshots.ts
+++ b/convex/pythBuybackSnapshots.ts
@@ -1,0 +1,457 @@
+import { Connection, PublicKey } from "@solana/web3.js";
+import { v } from "convex/values";
+import {
+  internalAction,
+  internalMutation,
+  mutation,
+  query,
+} from "./_generated/server";
+
+const PYTHIAN_COUNCIL_OPS_MULTISIG_ADDRESS =
+  "GAdn7TZhszf5KTfwNRx3A2nP6KCRFEWucZubgdEqbJA2";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const PYTH_MINT = "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3";
+const BUYBACK_STATE_KEY = "council_ops_usdc_pyth";
+
+const RPC_ENDPOINTS = [
+  "https://solana-mainnet.g.alchemy.com/v2/VAWGO1qOMcxkm0B9H0xUPzpNMzBnIvo8",
+  "https://api.mainnet-beta.solana.com",
+  "https://rpc.ankr.com/solana",
+  "https://solana-api.projectserum.com",
+];
+
+const CONNECTION_CONFIG = {
+  commitment: "confirmed" as const,
+  confirmTransactionInitialTimeout: 60000,
+  disableRetryOnRateLimit: false,
+  httpHeaders: {
+    "User-Agent": "PythBoard/1.0",
+  },
+};
+
+function computeWeightedAverage(totalUsdcSpent: number, totalPythBought: number) {
+  if (totalPythBought <= 0) {
+    return 0;
+  }
+  return totalUsdcSpent / totalPythBought;
+}
+
+function getTokenTotalForOwner(
+  balances:
+    | Array<{
+        mint: string;
+        owner?: string;
+        uiTokenAmount: { uiAmount?: number | null };
+      }>
+    | undefined,
+  ownerAddress: string,
+  mint: string
+): number {
+  if (!balances) {
+    return 0;
+  }
+
+  let total = 0;
+  for (const balance of balances) {
+    if (balance.owner !== ownerAddress || balance.mint !== mint) {
+      continue;
+    }
+    total += balance.uiTokenAmount.uiAmount ?? 0;
+  }
+
+  return total;
+}
+
+function getSwapDeltasForCouncilOps(
+  tx: Awaited<ReturnType<Connection["getParsedTransaction"]>>,
+  ownerAddress: string
+): { usdcSpent: number; pythReceived: number } {
+  if (!tx?.meta) {
+    return { usdcSpent: 0, pythReceived: 0 };
+  }
+
+  if (tx.meta.err) {
+    return { usdcSpent: 0, pythReceived: 0 };
+  }
+
+  const preUsdc = getTokenTotalForOwner(
+    tx.meta.preTokenBalances as
+      | Array<{
+          mint: string;
+          owner?: string;
+          uiTokenAmount: { uiAmount?: number | null };
+        }>
+      | undefined,
+    ownerAddress,
+    USDC_MINT
+  );
+  const postUsdc = getTokenTotalForOwner(
+    tx.meta.postTokenBalances as
+      | Array<{
+          mint: string;
+          owner?: string;
+          uiTokenAmount: { uiAmount?: number | null };
+        }>
+      | undefined,
+    ownerAddress,
+    USDC_MINT
+  );
+  const prePyth = getTokenTotalForOwner(
+    tx.meta.preTokenBalances as
+      | Array<{
+          mint: string;
+          owner?: string;
+          uiTokenAmount: { uiAmount?: number | null };
+        }>
+      | undefined,
+    ownerAddress,
+    PYTH_MINT
+  );
+  const postPyth = getTokenTotalForOwner(
+    tx.meta.postTokenBalances as
+      | Array<{
+          mint: string;
+          owner?: string;
+          uiTokenAmount: { uiAmount?: number | null };
+        }>
+      | undefined,
+    ownerAddress,
+    PYTH_MINT
+  );
+
+  const usdcSpent = Math.max(0, preUsdc - postUsdc);
+  const pythReceived = Math.max(0, postPyth - prePyth);
+
+  if (usdcSpent <= 0 || pythReceived <= 0) {
+    return { usdcSpent: 0, pythReceived: 0 };
+  }
+
+  return { usdcSpent, pythReceived };
+}
+
+async function fetchNewSignaturesSinceCursor(
+  connection: Connection,
+  owner: PublicKey,
+  latestProcessedSignature?: string
+): Promise<string[]> {
+  const signatures: string[] = [];
+  let before: string | undefined;
+  const MAX_SIGNATURES_PER_RUN = 300;
+
+  while (true) {
+    if (signatures.length >= MAX_SIGNATURES_PER_RUN) {
+      break;
+    }
+
+    const page = await connection.getSignaturesForAddress(owner, {
+      limit: 100,
+      before,
+      until: latestProcessedSignature,
+    });
+
+    if (page.length === 0) {
+      break;
+    }
+
+    signatures.push(...page.map((entry) => entry.signature));
+
+    if (page.length < 100) {
+      break;
+    }
+
+    before = page[page.length - 1].signature;
+  }
+
+  return signatures;
+}
+
+async function fetchLatestSignature(
+  connection: Connection,
+  owner: PublicKey
+): Promise<string | undefined> {
+  const page = await connection.getSignaturesForAddress(owner, {
+    limit: 1,
+  });
+  return page[0]?.signature;
+}
+
+export const upsertBuybackState = internalMutation({
+  args: {
+    key: v.string(),
+    latestProcessedSignature: v.optional(v.string()),
+    totalUsdcSpent: v.number(),
+    totalPythBought: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("pythBuybackState")
+      .withIndex("by_key", (q) => q.eq("key", args.key))
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        latestProcessedSignature: args.latestProcessedSignature,
+        totalUsdcSpent: args.totalUsdcSpent,
+        totalPythBought: args.totalPythBought,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("pythBuybackState", args);
+  },
+});
+
+export const insertBuybackSnapshot = internalMutation({
+  args: {
+    timestampMs: v.number(),
+    minuteBucketMs: v.number(),
+    totalUsdcSpent: v.number(),
+    totalPythBought: v.number(),
+    avgBuyPriceUsd: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("pythBuybackSnapshots")
+      .withIndex("by_minuteBucketMs", (q) =>
+        q.eq("minuteBucketMs", args.minuteBucketMs)
+      )
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        timestampMs: args.timestampMs,
+        totalUsdcSpent: args.totalUsdcSpent,
+        totalPythBought: args.totalPythBought,
+        avgBuyPriceUsd: args.avgBuyPriceUsd,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("pythBuybackSnapshots", args);
+  },
+});
+
+export const runPythBuybackSnapshotJob = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const owner = new PublicKey(PYTHIAN_COUNCIL_OPS_MULTISIG_ADDRESS);
+
+    let lastError: unknown = null;
+    for (const endpoint of RPC_ENDPOINTS) {
+      try {
+        const connection = new Connection(endpoint, CONNECTION_CONFIG);
+
+        const state = await ctx.runQuery(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          "pythBuybackSnapshots:getBuybackState" as any,
+          { key: BUYBACK_STATE_KEY }
+        );
+
+        // Start-now behavior: initialize cursor to latest signature and avoid
+        // historical backfill scans on first run.
+        if (!state?.latestProcessedSignature) {
+          const latestSignature = await fetchLatestSignature(connection, owner);
+          const totalUsdcSpent = state?.totalUsdcSpent ?? 0;
+          const totalPythBought = state?.totalPythBought ?? 0;
+          const avgBuyPriceUsd = computeWeightedAverage(
+            totalUsdcSpent,
+            totalPythBought
+          );
+          const timestampMs = Date.now();
+          const minuteBucketMs = Math.floor(timestampMs / 60_000) * 60_000;
+
+          await ctx.runMutation(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            "pythBuybackSnapshots:upsertBuybackState" as any,
+            {
+              key: BUYBACK_STATE_KEY,
+              latestProcessedSignature: latestSignature,
+              totalUsdcSpent,
+              totalPythBought,
+            }
+          );
+
+          await ctx.runMutation(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            "pythBuybackSnapshots:insertBuybackSnapshot" as any,
+            {
+              timestampMs,
+              minuteBucketMs,
+              totalUsdcSpent,
+              totalPythBought,
+              avgBuyPriceUsd,
+            }
+          );
+
+          return {
+            endpoint,
+            initialized: true,
+            processedSignatures: 0,
+            deltaUsdcSpent: 0,
+            deltaPythBought: 0,
+            totalUsdcSpent,
+            totalPythBought,
+            avgBuyPriceUsd,
+            timestampMs,
+          };
+        }
+
+        const newSignatures = await fetchNewSignaturesSinceCursor(
+          connection,
+          owner,
+          state?.latestProcessedSignature
+        );
+
+        let deltaUsdcSpent = 0;
+        let deltaPythBought = 0;
+
+        if (newSignatures.length > 0) {
+          const parsedTransactions = await connection.getParsedTransactions(
+            newSignatures,
+            { maxSupportedTransactionVersion: 0 }
+          );
+
+          for (const tx of parsedTransactions) {
+            const deltas = getSwapDeltasForCouncilOps(
+              tx,
+              PYTHIAN_COUNCIL_OPS_MULTISIG_ADDRESS
+            );
+            deltaUsdcSpent += deltas.usdcSpent;
+            deltaPythBought += deltas.pythReceived;
+          }
+        }
+
+        const totalUsdcSpent =
+          (state?.totalUsdcSpent ?? 0) + Math.max(0, deltaUsdcSpent);
+        const totalPythBought =
+          (state?.totalPythBought ?? 0) + Math.max(0, deltaPythBought);
+        const avgBuyPriceUsd = computeWeightedAverage(
+          totalUsdcSpent,
+          totalPythBought
+        );
+
+        const timestampMs = Date.now();
+        const minuteBucketMs = Math.floor(timestampMs / 60_000) * 60_000;
+        const latestProcessedSignature =
+          newSignatures.length > 0
+            ? newSignatures[0]
+            : state?.latestProcessedSignature;
+
+        await ctx.runMutation(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          "pythBuybackSnapshots:upsertBuybackState" as any,
+          {
+            key: BUYBACK_STATE_KEY,
+            latestProcessedSignature,
+            totalUsdcSpent,
+            totalPythBought,
+          }
+        );
+
+        await ctx.runMutation(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          "pythBuybackSnapshots:insertBuybackSnapshot" as any,
+          {
+            timestampMs,
+            minuteBucketMs,
+            totalUsdcSpent,
+            totalPythBought,
+            avgBuyPriceUsd,
+          }
+        );
+
+        return {
+          endpoint,
+          processedSignatures: newSignatures.length,
+          deltaUsdcSpent,
+          deltaPythBought,
+          totalUsdcSpent,
+          totalPythBought,
+          avgBuyPriceUsd,
+          timestampMs,
+        };
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    const errorMessage =
+      lastError instanceof Error ? lastError.message : "Unknown error";
+    throw new Error(`Failed to run PYTH buyback snapshot job: ${errorMessage}`);
+  },
+});
+
+export const getBuybackState = query({
+  args: { key: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("pythBuybackState")
+      .withIndex("by_key", (q) => q.eq("key", args.key))
+      .first();
+  },
+});
+
+export const getPythBuybackSummary = query({
+  args: {},
+  handler: async (ctx) => {
+    const state = await ctx.db
+      .query("pythBuybackState")
+      .withIndex("by_key", (q) => q.eq("key", BUYBACK_STATE_KEY))
+      .first();
+
+    const firstSnapshot = await ctx.db
+      .query("pythBuybackSnapshots")
+      .withIndex("by_timestampMs", (q) => q.gte("timestampMs", 0))
+      .order("asc")
+      .first();
+
+    const latestSnapshot = await ctx.db
+      .query("pythBuybackSnapshots")
+      .withIndex("by_timestampMs", (q) => q.gte("timestampMs", 0))
+      .order("desc")
+      .first();
+
+    return {
+      totalUsdcSpent: state?.totalUsdcSpent ?? 0,
+      totalPythBought: state?.totalPythBought ?? 0,
+      avgBuyPriceUsd:
+        latestSnapshot?.avgBuyPriceUsd ??
+        computeWeightedAverage(state?.totalUsdcSpent ?? 0, state?.totalPythBought ?? 0),
+      latestProcessedSignature: state?.latestProcessedSignature ?? null,
+      lastUpdatedMs: latestSnapshot?.timestampMs ?? null,
+      trackingStartedMs: firstSnapshot?.timestampMs ?? null,
+    };
+  },
+});
+
+export const getPythBuybackHistory = query({
+  args: {},
+  handler: async (ctx) => {
+    const snapshots = await ctx.db
+      .query("pythBuybackSnapshots")
+      .withIndex("by_timestampMs", (q) => q.gte("timestampMs", 0))
+      .order("asc")
+      .collect();
+
+    return snapshots.map((snapshot) => ({
+      id: snapshot._id,
+      timestampMs: snapshot.timestampMs,
+      minuteBucketMs: snapshot.minuteBucketMs,
+      totalUsdcSpent: snapshot.totalUsdcSpent,
+      totalPythBought: snapshot.totalPythBought,
+      avgBuyPriceUsd: snapshot.avgBuyPriceUsd,
+    }));
+  },
+});
+
+export const triggerPythBuybackSnapshot = mutation({
+  args: {},
+  handler: async (ctx): Promise<unknown> => {
+    return await ctx.scheduler.runAfter(
+      0,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      "pythBuybackSnapshots:runPythBuybackSnapshotJob" as any,
+      {}
+    );
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -9,4 +9,19 @@ export default defineSchema({
   })
     .index("by_minuteBucketMs", ["minuteBucketMs"])
     .index("by_timestampMs", ["timestampMs"]),
+  pythBuybackSnapshots: defineTable({
+    timestampMs: v.number(),
+    minuteBucketMs: v.number(),
+    totalUsdcSpent: v.number(),
+    totalPythBought: v.number(),
+    avgBuyPriceUsd: v.number(),
+  })
+    .index("by_minuteBucketMs", ["minuteBucketMs"])
+    .index("by_timestampMs", ["timestampMs"]),
+  pythBuybackState: defineTable({
+    key: v.string(),
+    latestProcessedSignature: v.optional(v.string()),
+    totalUsdcSpent: v.number(),
+    totalPythBought: v.number(),
+  }).index("by_key", ["key"]),
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -23,5 +23,9 @@ export default defineSchema({
     latestProcessedSignature: v.optional(v.string()),
     totalUsdcSpent: v.number(),
     totalPythBought: v.number(),
+    totalUsdcSpentDirect: v.optional(v.number()),
+    totalPythBoughtDirect: v.optional(v.number()),
+    totalUsdcSpentDca: v.optional(v.number()),
+    totalPythBoughtDca: v.optional(v.number()),
   }).index("by_key", ["key"]),
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -27,5 +27,8 @@ export default defineSchema({
     totalPythBoughtDirect: v.optional(v.number()),
     totalUsdcSpentDca: v.optional(v.number()),
     totalPythBoughtDca: v.optional(v.number()),
+    baselineUsdcSpent: v.optional(v.number()),
+    baselinePythBought: v.optional(v.number()),
+    baselineStartedMs: v.optional(v.number()),
   }).index("by_key", ["key"]),
 });

--- a/docs/plans/2026-03-05-pyth-buyback-tracking-implementation.md
+++ b/docs/plans/2026-03-05-pyth-buyback-tracking-implementation.md
@@ -1,0 +1,485 @@
+# PYTH Buyback Tracking Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add durable hourly tracking of Council Ops `USDC -> PYTH` buybacks and display cumulative spend, cumulative PYTH bought, and weighted average buy price on the reserve page.
+
+**Architecture:** Use Convex as the source of truth for buyback snapshots. An hourly Convex internal action incrementally scans new Council Ops signatures, filters qualifying `USDC -> PYTH` swaps, updates cumulative totals idempotently, and persists a snapshot row. The reserve UI reads the latest buyback metrics and trend series from a dedicated Convex query.
+
+**Tech Stack:** Next.js App Router, TypeScript, Convex, Solana Web3.js, Recharts, Vitest.
+
+**Relevant skills:** @convex @nextjs-app-router-patterns @vercel-react-best-practices
+
+---
+
+### Task 1: Add test harness for buyback logic
+
+**Files:**
+- Modify: `package.json`
+- Create: `vitest.config.ts`
+- Create: `tests/smoke.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/smoke.test.ts
+import { describe, expect, it } from "vitest";
+
+describe("test harness", () => {
+  it("runs vitest", () => {
+    expect(1 + 1).toBe(2);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/smoke.test.ts`
+Expected: FAIL because `vitest` is not installed/configured.
+
+**Step 3: Write minimal implementation**
+
+```json
+// package.json (scripts/devDependencies excerpt)
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8"
+  }
+}
+```
+
+```ts
+// vitest.config.ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/smoke.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add package.json vitest.config.ts tests/smoke.test.ts
+git commit -m "test: add vitest harness for buyback tracking"
+```
+
+### Task 2: Add pure buyback math/filter utilities with TDD
+
+**Files:**
+- Create: `lib/buyback/metrics.ts`
+- Test: `tests/lib/buyback/metrics.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/lib/buyback/metrics.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  computeWeightedAverage,
+  isUsdcToPythBuy,
+  accumulateBuyback,
+} from "@/lib/buyback/metrics";
+
+describe("buyback metrics", () => {
+  it("computes weighted average safely", () => {
+    expect(computeWeightedAverage(1000, 250)).toBe(4);
+    expect(computeWeightedAverage(1000, 0)).toBe(0);
+  });
+
+  it("filters only USDC->PYTH positive buys", () => {
+    expect(
+      isUsdcToPythBuy({ inputMint: "USDC", pythReceived: 1.2, usdcSpent: 4.5 })
+    ).toBe(true);
+    expect(
+      isUsdcToPythBuy({ inputMint: "SOL", pythReceived: 1.2, usdcSpent: 4.5 })
+    ).toBe(false);
+  });
+
+  it("accumulates cumulative totals", () => {
+    const next = accumulateBuyback(
+      { totalUsdcSpent: 10, totalPythBought: 5 },
+      { deltaUsdcSpent: 6, deltaPythBought: 2 }
+    );
+
+    expect(next.totalUsdcSpent).toBe(16);
+    expect(next.totalPythBought).toBe(7);
+    expect(next.avgBuyPriceUsd).toBeCloseTo(16 / 7, 8);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/lib/buyback/metrics.test.ts`
+Expected: FAIL with module not found for `@/lib/buyback/metrics`.
+
+**Step 3: Write minimal implementation**
+
+```ts
+// lib/buyback/metrics.ts
+export type BuybackBase = {
+  totalUsdcSpent: number;
+  totalPythBought: number;
+};
+
+export function computeWeightedAverage(usdcSpent: number, pythBought: number) {
+  if (pythBought <= 0) return 0;
+  return usdcSpent / pythBought;
+}
+
+export function isUsdcToPythBuy(input: {
+  inputMint: string;
+  pythReceived: number;
+  usdcSpent: number;
+}) {
+  return (
+    input.inputMint === "USDC" &&
+    input.pythReceived > 0 &&
+    input.usdcSpent > 0
+  );
+}
+
+export function accumulateBuyback(
+  base: BuybackBase,
+  delta: { deltaUsdcSpent: number; deltaPythBought: number }
+) {
+  const totalUsdcSpent = base.totalUsdcSpent + Math.max(0, delta.deltaUsdcSpent);
+  const totalPythBought =
+    base.totalPythBought + Math.max(0, delta.deltaPythBought);
+
+  return {
+    totalUsdcSpent,
+    totalPythBought,
+    avgBuyPriceUsd: computeWeightedAverage(totalUsdcSpent, totalPythBought),
+  };
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/lib/buyback/metrics.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add lib/buyback/metrics.ts tests/lib/buyback/metrics.test.ts
+git commit -m "feat: add buyback metric utilities with tests"
+```
+
+### Task 3: Add Convex schema for buyback snapshots and state
+
+**Files:**
+- Modify: `convex/schema.ts`
+- Create: `convex/pythBuybackSnapshots.ts`
+- Modify: `convex/_generated/*` (generated by codegen)
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/lib/buyback/schema-contract.test.ts
+import { describe, expect, it } from "vitest";
+import schema from "../../convex/schema";
+
+describe("buyback schema contract", () => {
+  it("defines pythBuybackSnapshots table", () => {
+    expect(schema).toBeTruthy();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/lib/buyback/schema-contract.test.ts`
+Expected: FAIL initially due missing import path or table contract mismatch.
+
+**Step 3: Write minimal implementation**
+
+```ts
+// convex/schema.ts (additions)
+pythBuybackSnapshots: defineTable({
+  timestampMs: v.number(),
+  minuteBucketMs: v.number(),
+  totalUsdcSpent: v.number(),
+  totalPythBought: v.number(),
+  avgBuyPriceUsd: v.number(),
+}).index("by_timestampMs", ["timestampMs"])
+  .index("by_minuteBucketMs", ["minuteBucketMs"]),
+
+pythBuybackState: defineTable({
+  key: v.string(),
+  latestProcessedSignature: v.optional(v.string()),
+  totalUsdcSpent: v.number(),
+  totalPythBought: v.number(),
+}).index("by_key", ["key"]),
+```
+
+```ts
+// convex/pythBuybackSnapshots.ts (initial exports)
+export const getLatestBuybackSummary = query({ ... });
+export const getBuybackHistory = query({ ... });
+export const upsertBuybackState = internalMutation({ ... });
+export const insertBuybackSnapshot = internalMutation({ ... });
+```
+
+Run codegen:
+```bash
+npx convex codegen
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+- `npm run test -- tests/lib/buyback/schema-contract.test.ts`
+- `npm run lint`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add convex/schema.ts convex/pythBuybackSnapshots.ts convex/_generated tests/lib/buyback/schema-contract.test.ts
+git commit -m "feat: add convex buyback snapshot schema and queries"
+```
+
+### Task 4: Implement hourly incremental buyback snapshot job
+
+**Files:**
+- Modify: `convex/pythBuybackSnapshots.ts`
+- Modify: `convex/crons.ts`
+- Create: `tests/lib/buyback/incremental-job.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/lib/buyback/incremental-job.test.ts
+import { describe, expect, it } from "vitest";
+import { accumulateBuyback } from "@/lib/buyback/metrics";
+
+describe("incremental buyback accumulation", () => {
+  it("is idempotent for duplicate signature batch", () => {
+    const base = { totalUsdcSpent: 100, totalPythBought: 20 };
+    const once = accumulateBuyback(base, { deltaUsdcSpent: 10, deltaPythBought: 2 });
+    const twice = accumulateBuyback(once, { deltaUsdcSpent: 0, deltaPythBought: 0 });
+    expect(twice.totalUsdcSpent).toBe(110);
+    expect(twice.totalPythBought).toBe(22);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/lib/buyback/incremental-job.test.ts`
+Expected: FAIL until incremental job/state logic is wired and exported helpers compile.
+
+**Step 3: Write minimal implementation**
+
+Implement in `convex/pythBuybackSnapshots.ts`:
+- `runPythBuybackSnapshotJob` internal action
+- signature cursor logic using `pythBuybackState`
+- parser filtering for Council Ops `USDC -> PYTH`
+- cumulative update + snapshot insert
+
+Add cron:
+
+```ts
+// convex/crons.ts
+crons.interval(
+  "fetch pyth buyback metrics hourly",
+  { hours: 1 },
+  internal.pythBuybackSnapshots.runPythBuybackSnapshotJob,
+  {}
+);
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+- `npm run test -- tests/lib/buyback/incremental-job.test.ts`
+- `npx convex codegen`
+- `npm run lint`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add convex/pythBuybackSnapshots.ts convex/crons.ts convex/_generated tests/lib/buyback/incremental-job.test.ts
+git commit -m "feat: add hourly convex buyback snapshot job"
+```
+
+### Task 5: Add shared frontend types and formatting helpers
+
+**Files:**
+- Modify: `types/pythTypes.ts`
+- Create: `lib/buyback/format.ts`
+- Create: `tests/lib/buyback/format.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/lib/buyback/format.test.ts
+import { describe, expect, it } from "vitest";
+import { formatUsd, formatPythAmount, formatUsdPerPyth } from "@/lib/buyback/format";
+
+describe("buyback formatters", () => {
+  it("formats USD and USD/PYTH", () => {
+    expect(formatUsd(1200.5)).toContain("$");
+    expect(formatUsdPerPyth(0.42)).toContain("/");
+  });
+
+  it("formats token amounts", () => {
+    expect(formatPythAmount(1234.567)).toContain("1,234");
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/lib/buyback/format.test.ts`
+Expected: FAIL with module not found.
+
+**Step 3: Write minimal implementation**
+
+```ts
+// lib/buyback/format.ts
+export const formatUsd = (value: number) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+
+export const formatPythAmount = (value: number) =>
+  new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(value);
+
+export const formatUsdPerPyth = (value: number) => `${formatUsd(value)} / PYTH`;
+```
+
+Add new types in `types/pythTypes.ts`:
+- `PythBuybackSnapshot`
+- `PythBuybackSummary`
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/lib/buyback/format.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add types/pythTypes.ts lib/buyback/format.ts tests/lib/buyback/format.test.ts
+git commit -m "feat: add buyback types and formatting helpers"
+```
+
+### Task 6: Build reserve buyback UI components and wire to Convex
+
+**Files:**
+- Create: `components/reserve-buyback-summary.tsx`
+- Create: `components/reserve-buyback-chart.tsx`
+- Modify: `app/reserve/page.tsx`
+- Modify: `components/reserve-summary.tsx` (only if placement/layout needs adjustment)
+
+**Step 1: Write the failing test**
+
+```ts
+// tests/lib/buyback/presenter.test.ts
+import { describe, expect, it } from "vitest";
+
+function mapChartPoints(points: Array<{ avgBuyPriceUsd: number }>) {
+  return points.map((p) => p.avgBuyPriceUsd);
+}
+
+describe("buyback presenter", () => {
+  it("keeps price points ordered", () => {
+    expect(mapChartPoints([{ avgBuyPriceUsd: 1.2 }, { avgBuyPriceUsd: 1.4 }])).toEqual([1.2, 1.4]);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run build`
+Expected: FAIL because new components/imports/props are not implemented yet.
+
+**Step 3: Write minimal implementation**
+
+- `reserve-buyback-summary.tsx`:
+  - show `Total USDC Spent`, `Total PYTH Bought`, `Avg Buy Price`, `Last Updated`
+- `reserve-buyback-chart.tsx`:
+  - `useQuery(api.pythBuybackSnapshots.getBuybackHistory, {})`
+  - Recharts line/area for `avgBuyPriceUsd` over time
+- `app/reserve/page.tsx`:
+  - render new summary/chart sections
+  - preserve existing load/error behavior; add scoped fallback for buyback section
+
+**Step 4: Run test to verify it passes**
+
+Run:
+- `npm run lint`
+- `npm run build`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add app/reserve/page.tsx components/reserve-buyback-summary.tsx components/reserve-buyback-chart.tsx components/reserve-summary.tsx
+git commit -m "feat: show buyback KPIs and average price trend on reserve page"
+```
+
+### Task 7: Validate end-to-end flow and update docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/plans/2026-03-05-pyth-buyback-tracking-design.md` (link implementation PR/commit hash in footer notes)
+
+**Step 1: Write the failing test**
+
+```md
+# README acceptance checklist (manual)
+- [ ] Reserve page displays buyback summary block
+- [ ] Reserve page displays buyback price-over-time chart
+- [ ] Hourly cron exists for buyback snapshots
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+- `npm run lint`
+- `npm run build`
+- `npm run test`
+Expected: Fail if any unresolved wiring/type issue remains.
+
+**Step 3: Write minimal implementation**
+
+Update README with:
+- new buyback metrics description
+- data freshness note (hourly Convex snapshots)
+- scope note (Council Ops `USDC -> PYTH` only)
+
+**Step 4: Run test to verify it passes**
+
+Run:
+- `npm run lint`
+- `npm run build`
+- `npm run test`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add README.md docs/plans/2026-03-05-pyth-buyback-tracking-design.md
+git commit -m "docs: document reserve buyback tracking behavior"
+```
+
+## Rollout Notes
+- Deploy Convex functions before frontend release to avoid empty query errors.
+- Expect first meaningful buyback chart point within one hour of deployment.
+- If no qualifying swaps occur, chart may be flat but should still update timestamp.

--- a/lib/buyback/format.ts
+++ b/lib/buyback/format.ts
@@ -27,5 +27,10 @@ export function formatPythAmount(value: number): string {
 }
 
 export function formatUsdPerPyth(value: number): string {
-  return `${formatUsd(value)} / PYTH`;
+  return `${new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 5,
+    maximumFractionDigits: 5,
+  }).format(value)} / PYTH`;
 }

--- a/lib/buyback/format.ts
+++ b/lib/buyback/format.ts
@@ -1,0 +1,31 @@
+export function formatUsd(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function formatPythAmount(value: number): string {
+  if (value === 0) {
+    return "0";
+  }
+
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(2)}M`;
+  }
+
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(2)}K`;
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function formatUsdPerPyth(value: number): string {
+  return `${formatUsd(value)} / PYTH`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "pyth-board",
-  "version": "0.1.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pyth-board",
+      "version": "0.3.1",
       "dependencies": {
         "@pythnetwork/staking-sdk": "^0.3.0",
         "@radix-ui/react-dialog": "^1.1.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@vercel/speed-insights": "^1.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "convex": "^1.31.7",
+        "convex": "^1.32.0",
         "lucide-react": "^0.513.0",
         "next": "^16.1.1",
         "react": "^19.0.0",
@@ -1592,9 +1592,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.1.tgz",
-      "integrity": "sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
+      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1608,9 +1608,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.1.tgz",
-      "integrity": "sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
+      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
       "cpu": [
         "arm64"
       ],
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.1.tgz",
-      "integrity": "sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
       "cpu": [
         "x64"
       ],
@@ -1640,9 +1640,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.1.tgz",
-      "integrity": "sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
       "cpu": [
         "arm64"
       ],
@@ -1656,9 +1656,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.1.tgz",
-      "integrity": "sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
       "cpu": [
         "arm64"
       ],
@@ -1672,9 +1672,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.1.tgz",
-      "integrity": "sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
       "cpu": [
         "x64"
       ],
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.1.tgz",
-      "integrity": "sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
       "cpu": [
         "x64"
       ],
@@ -1704,9 +1704,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.1.tgz",
-      "integrity": "sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
       "cpu": [
         "arm64"
       ],
@@ -1720,9 +1720,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.1.tgz",
-      "integrity": "sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
       "cpu": [
         "x64"
       ],
@@ -3384,13 +3384,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3770,10 +3770,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4069,13 +4070,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -4159,9 +4160,10 @@
       }
     },
     "node_modules/bn.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-      "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
     },
     "node_modules/borsh": {
       "version": "0.3.1",
@@ -4511,13 +4513,14 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.31.7",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.31.7.tgz",
-      "integrity": "sha512-PtNMe1mAIOvA8Yz100QTOaIdgt2rIuWqencVXrb4McdhxBHZ8IJ1eXTnrgCC9HydyilGT1pOn+KNqT14mqn9fQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.32.0.tgz",
+      "integrity": "sha512-5FlajdLpW75pdLS+/CgGH5H6yeRuA+ru50AKJEYbJpmyILUS+7fdTvsdTaQ7ZFXMv0gE8mX4S+S3AtJ94k0mfw==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
-        "prettier": "^3.0.0"
+        "prettier": "^3.0.0",
+        "ws": "8.18.0"
       },
       "bin": {
         "convex": "bin/main.js"
@@ -4539,6 +4542,27 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/convex/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }
@@ -5753,15 +5777,16 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -5787,9 +5812,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -7048,9 +7073,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -7177,10 +7203,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7207,30 +7234,16 @@
       }
     },
     "node_modules/minizlib": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -7277,13 +7290,13 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
-      "integrity": "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
+      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@next/env": "16.1.1",
+        "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001579",
@@ -7297,14 +7310,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.1",
-        "@next/swc-darwin-x64": "16.1.1",
-        "@next/swc-linux-arm64-gnu": "16.1.1",
-        "@next/swc-linux-arm64-musl": "16.1.1",
-        "@next/swc-linux-x64-gnu": "16.1.1",
-        "@next/swc-linux-x64-musl": "16.1.1",
-        "@next/swc-win32-arm64-msvc": "16.1.1",
-        "@next/swc-win32-x64-msvc": "16.1.1",
+        "@next/swc-darwin-arm64": "16.1.6",
+        "@next/swc-darwin-x64": "16.1.6",
+        "@next/swc-linux-arm64-gnu": "16.1.6",
+        "@next/swc-linux-arm64-musl": "16.1.6",
+        "@next/swc-linux-x64-gnu": "16.1.6",
+        "@next/swc-linux-x64-musl": "16.1.6",
+        "@next/swc-win32-arm64-msvc": "16.1.6",
+        "@next/swc-win32-x64-msvc": "16.1.6",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {
@@ -8699,16 +8712,16 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
+      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
         "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
+        "minizlib": "^3.1.0",
         "yallist": "^5.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@vercel/speed-insights": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "convex": "^1.31.7",
+    "convex": "^1.32.0",
     "lucide-react": "^0.513.0",
     "next": "^16.1.1",
     "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "pyth-board",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/types/pythTypes.ts
+++ b/types/pythTypes.ts
@@ -100,3 +100,21 @@ export type JupiterDcaCouncilOpsStatus = {
   usdcBalanceVault: number;
   orders: JupiterDcaOrder[];
 };
+
+export type PythBuybackSnapshot = {
+  id: string;
+  timestampMs: number;
+  minuteBucketMs: number;
+  totalUsdcSpent: number;
+  totalPythBought: number;
+  avgBuyPriceUsd: number;
+};
+
+export type PythBuybackSummary = {
+  totalUsdcSpent: number;
+  totalPythBought: number;
+  avgBuyPriceUsd: number;
+  latestProcessedSignature: string | null;
+  lastUpdatedMs: number | null;
+  trackingStartedMs: number | null;
+};


### PR DESCRIPTION
Summary
- align buyback tracking UI, docs, and convex logic with the latest average Pyth buy-price tracking plan
- update package metadata + lockfile to version 0.3.1 so the new release reflects the tracked changes

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added buyback metrics dashboard on the reserve page, displaying total USDC spent, total PYTH bought, and weighted average buy price for Council Ops activity.
  * Enabled hourly tracking snapshots for buyback activity.

* **Style**
  * Improved sidebar mobile overlay styling with enhanced visual clarity.

* **Chores**
  * Updated version to 0.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->