### PR TITLE
Add weekly Pyth forum digest page and Convex news pipeline

### DIFF
--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { NewsHero } from "@/components/news/news-hero";
+import { NewsDigestCard } from "@/components/news/news-digest-card";
+import { NewsArchive } from "@/components/news/news-archive";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Loader2, Newspaper } from "lucide-react";
+import type { NewsDigest } from "@/lib/news/types";
+
+export default function NewsPage() {
+  const latestDigest = useQuery(api.news.getLatestDigest, {});
+  const archiveDigests = useQuery(api.news.listDigests, { limit: 12 });
+  const [selectedWeekKey, setSelectedWeekKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedWeekKey && latestDigest?.weekKey) {
+      setSelectedWeekKey(latestDigest.weekKey);
+    }
+  }, [latestDigest, selectedWeekKey]);
+
+  if (latestDigest === undefined || archiveDigests === undefined) {
+    return (
+      <div className="space-y-5">
+        <section className="relative overflow-hidden rounded-[30px] border border-white/10 bg-[linear-gradient(135deg,rgba(47,34,82,0.96)_0%,rgba(93,47,141,0.88)_54%,rgba(181,88,152,0.72)_100%)] px-6 py-7 shadow-[0_28px_70px_rgba(9,5,20,0.28)] sm:px-8">
+          <div className="space-y-3">
+            <div className="h-6 w-40 animate-pulse rounded-full bg-white/20" />
+            <div className="h-10 w-72 animate-pulse rounded-2xl bg-white/18" />
+            <div className="h-4 w-[32rem] max-w-full animate-pulse rounded-xl bg-white/12" />
+          </div>
+        </section>
+
+        <Card className="rounded-[28px] border-white/10 bg-[linear-gradient(148deg,rgba(255,255,255,0.06)_0%,rgba(255,255,255,0.02)_100%)] py-0 shadow-[0_20px_55px_rgba(8,5,18,0.2)]">
+          <CardContent className="flex items-center justify-center gap-3 p-8 text-[#c8c1dc]">
+            <Loader2 className="h-5 w-5 animate-spin" />
+            Loading weekly digest...
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!latestDigest || archiveDigests.length === 0) {
+    return (
+      <Card className="rounded-[28px] border-white/10 bg-[linear-gradient(148deg,rgba(255,255,255,0.06)_0%,rgba(255,255,255,0.02)_100%)] py-0 shadow-[0_20px_55px_rgba(8,5,18,0.2)]">
+        <CardContent className="flex min-h-[320px] flex-col items-center justify-center gap-4 p-8 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-[#342b47] text-white">
+            <Newspaper className="h-8 w-8" />
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-2xl font-bold text-white">Weekly Pyth Digest</h1>
+            <p className="max-w-xl text-sm leading-6 text-[#c8c1dc]">
+              No digest has been generated yet. Once the weekly forum job runs,
+              this page will show the latest digest and archive.
+            </p>
+          </div>
+          <Badge
+            variant="outline"
+            className="rounded-xl border-white/10 bg-[#2d2741] px-3 py-1 text-xs text-[#c3bdd6]"
+          >
+            Waiting for first weekly run
+          </Badge>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const digests = archiveDigests as NewsDigest[];
+  const selectedDigest =
+    digests.find((digest) => digest.weekKey === selectedWeekKey) ??
+    (latestDigest as NewsDigest);
+
+  return (
+    <div className="space-y-5 w-full min-w-0 overflow-x-hidden px-1 sm:px-2 lg:px-3">
+      <NewsHero digest={selectedDigest} />
+      <NewsDigestCard digest={selectedDigest} />
+      <NewsArchive
+        digests={digests}
+        selectedWeekKey={selectedDigest.weekKey}
+        onSelect={setSelectedWeekKey}
+      />
+    </div>
+  );
+}

--- a/app/reserve/page.tsx
+++ b/app/reserve/page.tsx
@@ -241,8 +241,7 @@ export default function ReservePage() {
                 Pyth Strategic Reserve
               </h1>
               <Badge
-                variant="outline"
-                className="rounded-xl border-white/10 bg-black/15 px-3 py-1 text-xs text-white/85"
+                className="rounded-full border border-cyan-300/35 bg-cyan-400/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-cyan-100 shadow-[0_8px_24px_rgba(73,224,255,0.16)]"
               >
                 BETA
               </Badge>

--- a/components/news/news-archive.tsx
+++ b/components/news/news-archive.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { NewsDigest } from "@/lib/news/types";
+
+type NewsArchiveProps = {
+  digests: NewsDigest[];
+  selectedWeekKey: string;
+  onSelect: (weekKey: string) => void;
+};
+
+export function NewsArchive({
+  digests,
+  selectedWeekKey,
+  onSelect,
+}: NewsArchiveProps) {
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-bold text-white sm:text-2xl">Archive</h2>
+          <p className="text-sm text-[#958daf]">
+            Browse recent digests without leaving the page.
+          </p>
+        </div>
+        <Badge
+          variant="outline"
+          className="rounded-xl border-white/10 bg-[#2d2741] px-3 py-1 text-xs text-[#c3bdd6]"
+        >
+          {digests.length} weeks
+        </Badge>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {digests.map((digest) => {
+          const selected = digest.weekKey === selectedWeekKey;
+
+          return (
+            <button
+              key={digest.weekKey}
+              className="text-left"
+              onClick={() => onSelect(digest.weekKey)}
+              type="button"
+            >
+              <Card
+                className={cn(
+                  "h-full rounded-[24px] border-white/10 bg-[linear-gradient(148deg,rgba(255,255,255,0.05)_0%,rgba(255,255,255,0.02)_100%)] py-0 transition-all hover:border-white/20 hover:bg-[#342b47]",
+                  selected &&
+                    "border-cyan-300/30 bg-[linear-gradient(148deg,rgba(58,44,91,0.92)_0%,rgba(37,29,58,0.9)_100%)] shadow-[0_16px_40px_rgba(8,5,18,0.22)]"
+                )}
+              >
+                <CardContent className="space-y-4 p-5">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#928bb0]">
+                        {digest.weekKey}
+                      </p>
+                      <h3 className="text-base font-semibold text-white">
+                        {digest.title}
+                      </h3>
+                    </div>
+                    {selected ? (
+                      <Badge className="rounded-xl border-cyan-300/20 bg-cyan-300/10 px-2.5 py-1 text-[10px] text-cyan-100">
+                        Viewing
+                      </Badge>
+                    ) : null}
+                  </div>
+
+                  <p className="text-sm leading-6 text-[#c8c1dc]">
+                    {digest.summary}
+                  </p>
+
+                  <div className="flex flex-wrap gap-2 text-xs text-[#9f97b8]">
+                    <span>{digest.sourceCounts.forumTopics} topics</span>
+                    <span>{digest.sourceCounts.forumPosts} posts</span>
+                  </div>
+                </CardContent>
+              </Card>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/news/news-archive.tsx
+++ b/components/news/news-archive.tsx
@@ -16,6 +16,12 @@ export function NewsArchive({
   selectedWeekKey,
   onSelect,
 }: NewsArchiveProps) {
+  const formatSummaryParagraphs = (summary: string) =>
+    summary
+      .split(/(?<=[.!?])\s+(?=[A-Z])/)
+      .map((paragraph) => paragraph.trim())
+      .filter(Boolean);
+
   return (
     <section className="space-y-4">
       <div className="flex items-center justify-between gap-3">
@@ -36,6 +42,7 @@ export function NewsArchive({
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         {digests.map((digest) => {
           const selected = digest.weekKey === selectedWeekKey;
+          const summaryParagraphs = formatSummaryParagraphs(digest.summary);
 
           return (
             <button
@@ -63,14 +70,21 @@ export function NewsArchive({
                     </div>
                     {selected ? (
                       <Badge className="rounded-xl border-cyan-300/20 bg-cyan-300/10 px-2.5 py-1 text-[10px] text-cyan-100">
-                        Viewing
+                        Selected
                       </Badge>
                     ) : null}
                   </div>
 
-                  <p className="text-sm leading-6 text-[#c8c1dc]">
-                    {digest.summary}
-                  </p>
+                  <div className="space-y-3">
+                    {summaryParagraphs.map((paragraph, index) => (
+                      <p
+                        key={`${digest.weekKey}-archive-summary-${index}`}
+                        className="text-sm leading-7 text-[#c8c1dc]"
+                      >
+                        {paragraph}
+                      </p>
+                    ))}
+                  </div>
 
                   <div className="flex flex-wrap gap-2 text-xs text-[#9f97b8]">
                     <span>{digest.sourceCounts.forumTopics} topics</span>

--- a/components/news/news-digest-card.tsx
+++ b/components/news/news-digest-card.tsx
@@ -1,0 +1,95 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { NewsDigest } from "@/lib/news/types";
+
+type NewsDigestCardProps = {
+  digest: NewsDigest;
+};
+
+export function NewsDigestCard({ digest }: NewsDigestCardProps) {
+  const cleanText = (text: string) =>
+    text
+      .replace(/^sources?:\s+/i, "")
+      .replace(/\s*\(Sources?:[\s\S]*$/i, "")
+      .trim();
+
+  const digestSections = digest.sections.map((section, index) => ({
+    id: `${section.title}-${index}`,
+    title: section.title,
+    summary:
+      section.summary ||
+      (section.bullets ?? [])
+        .map(cleanText)
+        .filter(Boolean)
+        .join(" "),
+    sources: section.sources ?? [],
+  }));
+
+  return (
+    <Card className="rounded-[28px] border-white/10 bg-[linear-gradient(148deg,rgba(255,255,255,0.06)_0%,rgba(255,255,255,0.02)_100%)] py-0 shadow-[0_20px_55px_rgba(8,5,18,0.2)]">
+      <CardContent className="space-y-6 p-6 sm:p-7">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <h2 className="text-2xl font-bold text-white sm:text-[30px]">
+              {digest.title}
+            </h2>
+            <p className="max-w-3xl text-sm leading-7 text-[#c9c3dc] sm:text-[15px]">
+              {digest.summary}
+            </p>
+          </div>
+
+          <Badge
+            variant="outline"
+            className="rounded-xl border-white/10 bg-[#2d2741] px-3 py-1 text-xs text-[#c3bdd6]"
+          >
+            {digest.status}
+          </Badge>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {digestSections.map((section) => (
+            <div
+              key={section.id}
+              className="rounded-[24px] border border-white/10 bg-[#2d263d]/80 p-5"
+            >
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#928bb0]">
+                    Section
+                  </p>
+                  <h3 className="text-base font-semibold text-white">
+                    {section.title}
+                  </h3>
+                  <p className="text-sm leading-6 text-[#c8c1dc]">
+                    {section.summary}
+                  </p>
+                </div>
+              </div>
+              {section.sources.length > 0 ? (
+                <div className="mt-5 flex flex-wrap gap-2">
+                  {section.sources.map((source) => (
+                    <a
+                      key={`${section.id}-${source.url}`}
+                      className="rounded-xl border border-cyan-300/20 bg-cyan-300/10 px-3 py-1 text-xs text-cyan-100 transition-colors hover:bg-cyan-300/20"
+                      href={source.url}
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      {source.label}
+                    </a>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 text-xs text-[#9f97b8]">
+          <span>{digest.sourceCounts.forumTopics} topics reviewed</span>
+          <span>{digest.sourceCounts.forumPosts} posts retained</span>
+          <span>Generated {new Date(digest.generatedAtMs).toLocaleString()}</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/news/news-digest-card.tsx
+++ b/components/news/news-digest-card.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { ExternalLink } from "lucide-react";
 import type { NewsDigest } from "@/lib/news/types";
 
 type NewsDigestCardProps = {
@@ -12,6 +13,11 @@ export function NewsDigestCard({ digest }: NewsDigestCardProps) {
       .replace(/^sources?:\s+/i, "")
       .replace(/\s*\(Sources?:[\s\S]*$/i, "")
       .trim();
+
+  const summaryParagraphs = digest.summary
+    .split(/(?<=[.!?])\s+(?=[A-Z])/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
 
   const digestSections = digest.sections.map((section, index) => ({
     id: `${section.title}-${index}`,
@@ -29,13 +35,25 @@ export function NewsDigestCard({ digest }: NewsDigestCardProps) {
     <Card className="rounded-[28px] border-white/10 bg-[linear-gradient(148deg,rgba(255,255,255,0.06)_0%,rgba(255,255,255,0.02)_100%)] py-0 shadow-[0_20px_55px_rgba(8,5,18,0.2)]">
       <CardContent className="space-y-6 p-6 sm:p-7">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="space-y-2">
+          <div className="space-y-3">
             <h2 className="text-2xl font-bold text-white sm:text-[30px]">
               {digest.title}
             </h2>
-            <p className="max-w-3xl text-sm leading-7 text-[#c9c3dc] sm:text-[15px]">
-              {digest.summary}
-            </p>
+            <div className="max-w-4xl rounded-[22px] border border-white/8 bg-white/[0.03] px-4 py-4 sm:px-5">
+              <p className="mb-3 text-[11px] font-semibold uppercase tracking-[0.16em] text-[#9e97b8]">
+                This Week
+              </p>
+              <div className="space-y-3">
+                {summaryParagraphs.map((paragraph, index) => (
+                  <p
+                    key={`${digest.weekKey}-summary-${index}`}
+                    className="max-w-[72ch] text-sm leading-8 text-[#d3cde4] sm:text-[15px]"
+                  >
+                    {paragraph}
+                  </p>
+                ))}
+              </div>
+            </div>
           </div>
 
           <Badge
@@ -50,34 +68,41 @@ export function NewsDigestCard({ digest }: NewsDigestCardProps) {
           {digestSections.map((section) => (
             <div
               key={section.id}
-              className="rounded-[24px] border border-white/10 bg-[#2d263d]/80 p-5"
+              className="rounded-[24px] border border-white/10 bg-[#2d263d]/80 p-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"
             >
-              <div className="space-y-4">
-                <div className="space-y-2">
+              <div className="space-y-5">
+                <div className="space-y-3">
                   <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#928bb0]">
                     Section
                   </p>
                   <h3 className="text-base font-semibold text-white">
                     {section.title}
                   </h3>
-                  <p className="text-sm leading-6 text-[#c8c1dc]">
+                  <p className="text-sm leading-7 text-[#c8c1dc]">
                     {section.summary}
                   </p>
                 </div>
               </div>
               {section.sources.length > 0 ? (
-                <div className="mt-5 flex flex-wrap gap-2">
+                <div className="mt-7 space-y-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-cyan-100/80">
+                    Related sources
+                  </p>
+                  <div className="flex flex-wrap gap-2.5">
                   {section.sources.map((source) => (
                     <a
                       key={`${section.id}-${source.url}`}
-                      className="rounded-xl border border-cyan-300/20 bg-cyan-300/10 px-3 py-1 text-xs text-cyan-100 transition-colors hover:bg-cyan-300/20"
+                      className="inline-flex cursor-pointer items-center gap-1.5 rounded-xl border border-cyan-300/35 bg-cyan-300/14 px-3.5 py-2 text-xs font-medium text-cyan-50 shadow-[0_0_0_1px_rgba(34,211,238,0.08)] transition-all hover:-translate-y-0.5 hover:bg-cyan-300/22 hover:text-white hover:shadow-[0_10px_24px_rgba(34,211,238,0.16)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/50"
                       href={source.url}
                       rel="noreferrer"
                       target="_blank"
+                      title={`Open source: ${source.label}`}
                     >
                       {source.label}
+                      <ExternalLink className="h-3.5 w-3.5 shrink-0 opacity-80" />
                     </a>
                   ))}
+                  </div>
                 </div>
               ) : null}
             </div>

--- a/components/news/news-hero.tsx
+++ b/components/news/news-hero.tsx
@@ -19,8 +19,15 @@ export function NewsHero({ digest }: NewsHeroProps) {
 
       <div className="relative flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="space-y-3">
-          <div className="inline-flex items-center rounded-full border border-white/12 bg-white/8 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/75">
-            Weekly forum digest
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="inline-flex items-center rounded-full border border-white/12 bg-white/8 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/75">
+              Weekly forum digest
+            </div>
+            <Badge
+              className="rounded-full border border-cyan-300/35 bg-cyan-400/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-cyan-100 shadow-[0_8px_24px_rgba(73,224,255,0.16)]"
+            >
+              BETA
+            </Badge>
           </div>
           <div className="space-y-2">
             <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
@@ -51,7 +58,7 @@ export function NewsHero({ digest }: NewsHeroProps) {
           Generated {new Date(digest.generatedAtMs).toLocaleString()}
         </span>
         <span className="hidden h-1 w-1 rounded-full bg-white/35 sm:block" />
-        <span>Source: Pyth forum proposals</span>
+        <span>Sources: Pyth forum proposals and ideas bank</span>
       </div>
     </section>
   );

--- a/components/news/news-hero.tsx
+++ b/components/news/news-hero.tsx
@@ -1,0 +1,58 @@
+import { Badge } from "@/components/ui/badge";
+
+type NewsHeroProps = {
+  digest: {
+    weekKey: string;
+    sourceCounts: {
+      forumPosts: number;
+      forumTopics: number;
+    };
+    generatedAtMs: number;
+  };
+};
+
+export function NewsHero({ digest }: NewsHeroProps) {
+  return (
+    <section className="relative overflow-hidden rounded-[30px] border border-white/10 bg-[linear-gradient(135deg,rgba(47,34,82,0.96)_0%,rgba(93,47,141,0.88)_54%,rgba(181,88,152,0.72)_100%)] px-6 py-7 shadow-[0_28px_70px_rgba(9,5,20,0.28)] sm:px-8">
+      <div className="pointer-events-none absolute -right-8 top-2 h-36 w-36 rounded-full bg-white/10 blur-3xl" />
+      <div className="pointer-events-none absolute bottom-[-28px] left-[38%] h-24 w-24 rounded-full bg-cyan-300/15 blur-2xl" />
+
+      <div className="relative flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-3">
+          <div className="inline-flex items-center rounded-full border border-white/12 bg-white/8 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/75">
+            Weekly forum digest
+          </div>
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+              Weekly Pyth Digest
+            </h1>
+            <p className="max-w-2xl text-sm leading-6 text-white/80 sm:text-base">
+              A stored weekly summary of high-signal activity from the Pyth
+              governance forum, designed to help token holders catch up quickly.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+          <Badge className="rounded-xl border-white/12 bg-white/10 px-3 py-1 text-white">
+            Week key {digest.weekKey}
+          </Badge>
+          <Badge className="rounded-xl border-white/12 bg-[#2a1e44] px-3 py-1 text-white/90">
+            {digest.sourceCounts.forumTopics} topics
+          </Badge>
+          <Badge className="rounded-xl border-white/12 bg-[#2a1e44] px-3 py-1 text-white/90">
+            {digest.sourceCounts.forumPosts} posts
+          </Badge>
+        </div>
+      </div>
+
+      <div className="relative mt-6 flex flex-wrap items-center gap-3 text-xs text-white/70 sm:text-sm">
+        <span>
+          Generated {new Date(digest.generatedAtMs).toLocaleString()}
+        </span>
+        <span className="hidden h-1 w-1 rounded-full bg-white/35 sm:block" />
+        <span>Source: Pyth forum proposals</span>
+      </div>
+    </section>
+  );
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -5,6 +5,7 @@ import {
   Wallet,
   Image as ImageIcon,
   Building2,
+  Newspaper,
   ArrowUpRight,
 } from "lucide-react";
 import { TwitterIcon } from "@/components/icons/twitter-icon";
@@ -28,6 +29,7 @@ export function Sidebar({
     { href: "/wallets", label: "Wallets", icon: Wallet },
     { href: "/pythenians", label: "Pythenians", icon: ImageIcon },
     { href: "/reserve", label: "Reserve", icon: Building2 },
+    { href: "/news", label: "News", icon: Newspaper },
   ];
 
   const isActive = (path: string) => {

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as crons from "../crons.js";
+import type * as news from "../news.js";
 import type * as pythBuybackSnapshots from "../pythBuybackSnapshots.js";
 import type * as reserveSnapshots from "../reserveSnapshots.js";
 
@@ -20,6 +21,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   crons: typeof crons;
+  news: typeof news;
   pythBuybackSnapshots: typeof pythBuybackSnapshots;
   reserveSnapshots: typeof reserveSnapshots;
 }>;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -17,4 +17,11 @@ crons.interval(
   {}
 );
 
+crons.weekly(
+  "generate weekly pyth digest",
+  { dayOfWeek: "thursday", hourUTC: 1, minuteUTC: 0 },
+  internal.news.generateWeeklyDigest,
+  {}
+);
+
 export default crons;

--- a/convex/news.ts
+++ b/convex/news.ts
@@ -1,0 +1,526 @@
+import { v } from "convex/values";
+import {
+  internalAction,
+  internalMutation,
+  mutation,
+  query,
+} from "./_generated/server";
+import { buildDigestPrompt } from "../lib/news/prompt";
+import {
+  getDigestResponseSchema,
+  parseDigestResponse,
+  type DigestOutput,
+} from "../lib/news/openai";
+import {
+  getCandidateTopicsForWindow,
+  getDigestWindowPosts,
+  normalizeTopicPostToSourceItem,
+  summarizeSourceCounts,
+} from "../lib/news/forum";
+import { shouldKeepPostForDigest } from "../lib/news/filter";
+import {
+  buildDigestWeekWindow,
+  formatWeekKey,
+  formatWeekLabel,
+} from "../lib/news/week";
+
+const FORUM_BASE_URL = "https://forum.pyth.network";
+const FORUM_CATEGORY_FEEDS = [
+  {
+    category: "proposals",
+    url: `${FORUM_BASE_URL}/c/proposals/7/l/latest.json`,
+  },
+  {
+    category: "ideas-bank",
+    url: `${FORUM_BASE_URL}/c/ideas-bank/2/l/latest.json`,
+  },
+] as const;
+const DEFAULT_OPENAI_MODEL = "gpt-4.1-mini";
+const PROMPT_VERSION = "v1";
+
+const digestSectionValidator = v.object({
+  title: v.string(),
+  summary: v.optional(v.string()),
+  bullets: v.optional(v.array(v.string())),
+  sources: v.optional(
+    v.array(
+      v.object({
+        label: v.string(),
+        url: v.string(),
+      })
+    )
+  ),
+});
+
+const sourceItemValidator = v.object({
+  source: v.string(),
+  category: v.string(),
+  topicId: v.number(),
+  postId: v.number(),
+  topicTitle: v.string(),
+  topicSlug: v.string(),
+  url: v.string(),
+  authorUsername: v.string(),
+  authorName: v.optional(v.string()),
+  createdAtMs: v.number(),
+  weekKey: v.string(),
+  isTopicOp: v.boolean(),
+  isNewTopicThisWeek: v.boolean(),
+  contentText: v.string(),
+  rawJson: v.string(),
+  signalScore: v.number(),
+});
+
+type DigestSection = {
+  title: string;
+  summary?: string;
+  bullets?: string[];
+  sources?: Array<{
+    label: string;
+    url: string;
+  }>;
+};
+
+type SourceItem = {
+  source: string;
+  category: string;
+  topicId: number;
+  postId: number;
+  topicTitle: string;
+  topicSlug: string;
+  url: string;
+  authorUsername: string;
+  authorName?: string;
+  createdAtMs: number;
+  weekKey: string;
+  isTopicOp: boolean;
+  isNewTopicThisWeek: boolean;
+  contentText: string;
+  rawJson: string;
+  signalScore: number;
+};
+
+type ForumTopic = {
+  id: number;
+  slug: string;
+  title: string;
+  created_at: string;
+  last_posted_at: string;
+};
+
+type ForumTopicPost = {
+  id: number;
+  post_number: number;
+  created_at: string;
+  username: string;
+  name?: string | null;
+  cooked: string;
+};
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent": "PythBoard/1.0",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed for ${url}: ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+function getDigestEndMs(nowMs: number) {
+  const now = new Date(nowMs);
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+}
+
+async function collectForumSourceItems(input: {
+  weekKey: string;
+  rangeStartMs: number;
+  rangeEndMs: number;
+}): Promise<SourceItem[]> {
+  const topicItems = await Promise.all(
+    FORUM_CATEGORY_FEEDS.map(async ({ category, url }) => {
+      const latest = await fetchJson<{
+        topic_list?: {
+          topics?: ForumTopic[];
+        };
+      }>(url);
+
+      const candidateTopics = getCandidateTopicsForWindow(
+        latest.topic_list?.topics ?? [],
+        {
+          startMs: input.rangeStartMs,
+          endMs: input.rangeEndMs,
+        }
+      );
+
+      return await Promise.all(
+        candidateTopics.map(async (topic) => {
+          const topicJson = await fetchJson<{
+            post_stream?: {
+              posts?: ForumTopicPost[];
+            };
+          }>(`${FORUM_BASE_URL}/t/${topic.slug}/${topic.id}.json`);
+
+          const weeklyPosts = getDigestWindowPosts(
+            topicJson.post_stream?.posts ?? [],
+            {
+              startMs: input.rangeStartMs,
+              endMs: input.rangeEndMs,
+            }
+          );
+
+          return weeklyPosts
+            .map((post) =>
+              normalizeTopicPostToSourceItem({
+                category,
+                weekKey: input.weekKey,
+                topic,
+                post,
+                rangeStartMs: input.rangeStartMs,
+              })
+            )
+            .filter((item) => shouldKeepPostForDigest(item));
+        })
+      );
+    })
+  );
+
+  return topicItems
+    .flat(2)
+    .sort((a, b) => a.createdAtMs - b.createdAtMs);
+}
+
+function buildQuietWeekDigest(weekLabel: string) {
+  return {
+    title: `Weekly Pyth Digest`,
+    summary: `Quiet week on the Pyth forum for ${weekLabel}. No major proposal or ideas activity made the digest threshold.`,
+    sections: [
+      {
+        title: "Forum activity",
+        summary:
+          "No major proposal or ideas activity reached the weekly digest threshold.",
+        sources: [],
+      },
+    ],
+  };
+}
+
+function getResponseText(payload: unknown) {
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "output_text" in payload &&
+    typeof payload.output_text === "string"
+  ) {
+    return payload.output_text;
+  }
+
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "output" in payload &&
+    Array.isArray(payload.output)
+  ) {
+    for (const outputItem of payload.output) {
+      if (
+        outputItem &&
+        typeof outputItem === "object" &&
+        "content" in outputItem &&
+        Array.isArray(outputItem.content)
+      ) {
+        for (const contentItem of outputItem.content) {
+          if (
+            contentItem &&
+            typeof contentItem === "object" &&
+            "type" in contentItem &&
+            contentItem.type === "output_text" &&
+            "text" in contentItem &&
+            typeof contentItem.text === "string"
+          ) {
+            return contentItem.text;
+          }
+        }
+      }
+    }
+  }
+
+  throw new Error("OpenAI response did not include output text");
+}
+
+async function generateDigestWithOpenAI(input: {
+  weekLabel: string;
+  sourceItems: SourceItem[];
+}): Promise<DigestOutput> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not configured");
+  }
+
+  const model = process.env.OPENAI_MODEL ?? DEFAULT_OPENAI_MODEL;
+  const prompt = buildDigestPrompt(input);
+
+  const response = await fetch("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      input: [
+        {
+          role: "system",
+          content:
+            "You summarize Pyth forum proposal activity for retail PYTH holders.",
+        },
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+      text: {
+        format: {
+          type: "json_schema",
+          name: "weekly_pyth_digest",
+          strict: true,
+          schema: getDigestResponseSchema(),
+        },
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`OpenAI Responses API failed: ${response.status} ${body}`);
+  }
+
+  const payload = (await response.json()) as unknown;
+  const outputText = getResponseText(payload);
+  return parseDigestResponse(JSON.parse(outputText) as DigestOutput);
+}
+
+export const upsertSourceItems = internalMutation({
+  args: {
+    weekKey: v.string(),
+    items: v.array(sourceItemValidator),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("newsSourceItems")
+      .withIndex("by_weekKey", (q) => q.eq("weekKey", args.weekKey))
+      .collect();
+
+    await Promise.all(existing.map((doc) => ctx.db.delete(doc._id)));
+
+    const insertedIds = [];
+    for (const item of args.items) {
+      insertedIds.push(await ctx.db.insert("newsSourceItems", item));
+    }
+
+    return insertedIds;
+  },
+});
+
+export const saveDigest = internalMutation({
+  args: {
+    weekKey: v.string(),
+    rangeStartMs: v.number(),
+    rangeEndMs: v.number(),
+    status: v.string(),
+    title: v.string(),
+    summary: v.string(),
+    sections: v.array(digestSectionValidator),
+    sourceCounts: v.object({
+      forumPosts: v.number(),
+      forumTopics: v.number(),
+    }),
+    model: v.string(),
+    promptVersion: v.string(),
+    generatedAtMs: v.number(),
+    errorMessage: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("newsDigests")
+      .withIndex("by_weekKey", (q) => q.eq("weekKey", args.weekKey))
+      .first();
+
+    const digest = {
+      weekKey: args.weekKey,
+      rangeStartMs: args.rangeStartMs,
+      rangeEndMs: args.rangeEndMs,
+      status: args.status,
+      title: args.title,
+      summary: args.summary,
+      sections: args.sections,
+      sourceCounts: args.sourceCounts,
+      model: args.model,
+      promptVersion: args.promptVersion,
+      generatedAtMs: args.generatedAtMs,
+      errorMessage: args.errorMessage,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, digest);
+      return existing._id;
+    }
+
+    return await ctx.db.insert("newsDigests", digest);
+  },
+});
+
+export const getDigestByWeekKey = query({
+  args: {
+    weekKey: v.string(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("newsDigests")
+      .withIndex("by_weekKey", (q) => q.eq("weekKey", args.weekKey))
+      .first();
+  },
+});
+
+export const getLatestDigest = query({
+  args: {},
+  handler: async (ctx) => {
+    const digests = await ctx.db
+      .query("newsDigests")
+      .withIndex("by_generatedAtMs")
+      .order("desc")
+      .collect();
+
+    return digests.find((digest) => digest.status === "completed") ?? null;
+  },
+});
+
+export const listDigests = query({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = Math.max(1, Math.min(args.limit ?? 12, 24));
+    const digests = await ctx.db
+      .query("newsDigests")
+      .withIndex("by_generatedAtMs")
+      .order("desc")
+      .take(limit);
+
+    return digests.filter((digest) => digest.status === "completed");
+  },
+});
+
+export const generateWeeklyDigest = internalAction({
+  args: {
+    force: v.optional(v.boolean()),
+    endMs: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const digestEndMs = getDigestEndMs(args.endMs ?? Date.now());
+    const { startMs: rangeStartMs, endMs: rangeEndMs } =
+      buildDigestWeekWindow(digestEndMs);
+    const weekKey = formatWeekKey(digestEndMs);
+    const existing = (await ctx.runQuery("news:getDigestByWeekKey" as any, {
+      weekKey,
+    })) as
+      | {
+          status: string;
+        }
+      | null;
+
+    if (existing?.status === "completed" && !args.force) {
+      return {
+        skipped: true,
+        weekKey,
+      };
+    }
+
+    const generatedAtMs = Date.now();
+    const weekLabel = formatWeekLabel(digestEndMs);
+    const model = process.env.OPENAI_MODEL ?? DEFAULT_OPENAI_MODEL;
+
+    try {
+      const sourceItems = await collectForumSourceItems({
+        weekKey,
+        rangeStartMs,
+        rangeEndMs,
+      });
+
+      await ctx.runMutation("news:upsertSourceItems" as any, {
+        weekKey,
+        items: sourceItems,
+      });
+
+      const sourceCounts = summarizeSourceCounts(sourceItems);
+      const digest =
+        sourceItems.length === 0
+          ? buildQuietWeekDigest(weekLabel)
+          : await generateDigestWithOpenAI({
+              weekLabel,
+              sourceItems,
+            });
+
+      await ctx.runMutation("news:saveDigest" as any, {
+        weekKey,
+        rangeStartMs,
+        rangeEndMs,
+        status: "completed",
+        title: digest.title,
+        summary: digest.summary,
+        sections: digest.sections as DigestSection[],
+        sourceCounts,
+        model,
+        promptVersion: PROMPT_VERSION,
+        generatedAtMs,
+        errorMessage: undefined,
+      });
+
+      return {
+        weekKey,
+        sourceCounts,
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
+
+      await ctx.runMutation("news:saveDigest" as any, {
+        weekKey,
+        rangeStartMs,
+        rangeEndMs,
+        status: "failed",
+        title: "Weekly Pyth Digest",
+        summary: "Digest generation failed.",
+        sections: [],
+        sourceCounts: {
+          forumPosts: 0,
+          forumTopics: 0,
+        },
+        model,
+        promptVersion: PROMPT_VERSION,
+        generatedAtMs,
+        errorMessage: errorMessage.slice(0, 500),
+      });
+
+      throw error;
+    }
+  },
+});
+
+export const triggerDigestGeneration = mutation({
+  args: {
+    force: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args): Promise<unknown> => {
+    return await ctx.scheduler.runAfter(
+      0,
+      "news:generateWeeklyDigest" as any,
+      {
+        force: args.force,
+      }
+    );
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -30,4 +30,58 @@ export default defineSchema({
     totalUsdcSpentLimitOrders: v.optional(v.number()),
     totalPythBoughtLimitOrders: v.optional(v.number()),
   }).index("by_key", ["key"]),
+  newsSourceItems: defineTable({
+    source: v.string(),
+    category: v.string(),
+    topicId: v.number(),
+    postId: v.number(),
+    topicTitle: v.string(),
+    topicSlug: v.string(),
+    url: v.string(),
+    authorUsername: v.string(),
+    authorName: v.optional(v.string()),
+    createdAtMs: v.number(),
+    weekKey: v.string(),
+    isTopicOp: v.boolean(),
+    isNewTopicThisWeek: v.boolean(),
+    contentText: v.string(),
+    rawJson: v.string(),
+    signalScore: v.number(),
+  })
+    .index("by_weekKey", ["weekKey"])
+    .index("by_topicId", ["topicId"])
+    .index("by_source_and_weekKey", ["source", "weekKey"]),
+  newsDigests: defineTable({
+    weekKey: v.string(),
+    rangeStartMs: v.number(),
+    rangeEndMs: v.number(),
+    status: v.string(),
+    title: v.string(),
+    summary: v.string(),
+    sections: v.array(
+      v.object({
+        title: v.string(),
+        summary: v.optional(v.string()),
+        bullets: v.optional(v.array(v.string())),
+        sources: v.optional(
+          v.array(
+            v.object({
+              label: v.string(),
+              url: v.string(),
+            })
+          )
+        ),
+      })
+    ),
+    sourceCounts: v.object({
+      forumPosts: v.number(),
+      forumTopics: v.number(),
+    }),
+    model: v.string(),
+    promptVersion: v.string(),
+    generatedAtMs: v.number(),
+    errorMessage: v.optional(v.string()),
+  })
+    .index("by_weekKey", ["weekKey"])
+    .index("by_generatedAtMs", ["generatedAtMs"]),
 });

--- a/docs/plans/2026-03-18-news-digest-implementation.md
+++ b/docs/plans/2026-03-18-news-digest-implementation.md
@@ -1,0 +1,767 @@
+# Weekly Pyth Digest Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a `/news` page that shows a stored weekly digest of high-signal Pyth forum activity, generated every Thursday from the Pyth forum Proposals category and rendered in the app's existing subpage visual style.
+
+**Architecture:** Use Convex as the durable source of truth for both normalized weekly forum source items and the generated digest. A weekly Convex internal action fetches recent proposal topics from the live Discourse JSON feed, loads topic JSON for threads active in the weekly window, filters to meaningful posts created in that window, generates a structured digest via the OpenAI Responses API, and saves the result keyed by `weekKey`. The Next.js `/news` page reads the latest digest and archive from Convex and renders them with dashboard-style cards consistent with `/reserve`.
+
+**Tech Stack:** Next.js App Router, TypeScript, Convex, OpenAI Responses API, Vitest, Tailwind CSS, existing `components/ui` primitives.
+
+**Relevant skills:** @convex @nextjs-app-router-patterns @vercel-react-best-practices
+
+---
+
+### Task 1: Add test harness for news-domain utilities
+
+**Files:**
+- Modify: `package.json`
+- Create: `vitest.config.ts`
+- Create: `tests/news/smoke.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+
+describe("news test harness", () => {
+  it("runs vitest", () => {
+    expect(1 + 1).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/news/smoke.test.ts`
+Expected: FAIL because Vitest is not installed or configured.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```json
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8"
+  }
+}
+```
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/news/smoke.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json vitest.config.ts tests/news/smoke.test.ts
+git commit -m "test: add vitest harness for news digest"
+```
+
+### Task 2: Add pure week-window and formatting utilities with TDD
+
+**Files:**
+- Create: `lib/news/week.ts`
+- Test: `tests/news/week.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  buildDigestWeekWindow,
+  formatWeekKey,
+  formatWeekLabel,
+} from "@/lib/news/week";
+
+describe("news week helpers", () => {
+  it("builds a Thursday-to-Thursday UTC window", () => {
+    const end = Date.parse("2026-03-19T00:00:00.000Z");
+    const window = buildDigestWeekWindow(end);
+
+    expect(window.startMs).toBe(Date.parse("2026-03-12T00:00:00.000Z"));
+    expect(window.endMs).toBe(end);
+  });
+
+  it("formats a stable week key", () => {
+    expect(formatWeekKey(Date.parse("2026-03-19T00:00:00.000Z"))).toBe(
+      "2026-03-19"
+    );
+  });
+
+  it("formats a user-facing label", () => {
+    expect(formatWeekLabel(Date.parse("2026-03-19T00:00:00.000Z"))).toBe(
+      "Week of Mar 19, 2026"
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/news/week.test.ts`
+Expected: FAIL with module not found for `@/lib/news/week`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+export function buildDigestWeekWindow(endMs: number) {
+  const weekMs = 7 * 24 * 60 * 60 * 1000;
+  return {
+    startMs: endMs - weekMs,
+    endMs,
+  };
+}
+
+export function formatWeekKey(endMs: number) {
+  return new Date(endMs).toISOString().slice(0, 10);
+}
+
+export function formatWeekLabel(endMs: number) {
+  const formatted = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(endMs));
+  return `Week of ${formatted}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/news/week.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/news/week.ts tests/news/week.test.ts
+git commit -m "feat: add weekly digest date helpers"
+```
+
+### Task 3: Add forum normalization and filtering utilities with TDD
+
+**Files:**
+- Create: `lib/news/forum.ts`
+- Create: `lib/news/filter.ts`
+- Test: `tests/news/forum.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  getCandidateTopicsForWindow,
+  normalizeTopicPostToSourceItem,
+  stripCookedHtmlToText,
+} from "@/lib/news/forum";
+import { shouldKeepPostForDigest } from "@/lib/news/filter";
+
+describe("forum news utilities", () => {
+  const startMs = Date.parse("2026-03-12T00:00:00.000Z");
+  const endMs = Date.parse("2026-03-19T00:00:00.000Z");
+
+  it("keeps topics created or updated inside the digest window", () => {
+    const topics = [
+      {
+        id: 1,
+        slug: "fresh-proposal",
+        title: "Fresh Proposal",
+        created_at: "2026-03-14T12:00:00.000Z",
+        last_posted_at: "2026-03-14T12:00:00.000Z",
+      },
+      {
+        id: 2,
+        slug: "older-thread",
+        title: "Older Thread",
+        created_at: "2026-03-01T12:00:00.000Z",
+        last_posted_at: "2026-03-16T12:00:00.000Z",
+      },
+      {
+        id: 3,
+        slug: "stale-thread",
+        title: "Stale Thread",
+        created_at: "2026-03-01T12:00:00.000Z",
+        last_posted_at: "2026-03-05T12:00:00.000Z",
+      },
+    ];
+
+    expect(getCandidateTopicsForWindow(topics, { startMs, endMs })).toHaveLength(2);
+  });
+
+  it("converts cooked HTML into text", () => {
+    expect(stripCookedHtmlToText("<p>Hello <strong>world</strong></p>")).toBe(
+      "Hello world"
+    );
+  });
+
+  it("marks OP posts for new topics correctly", () => {
+    const item = normalizeTopicPostToSourceItem({
+      category: "proposals",
+      weekKey: "2026-03-19",
+      topic: {
+        id: 2401,
+        slug: "laas",
+        title: "LaaS",
+        created_at: "2026-03-14T00:00:00.000Z",
+      },
+      post: {
+        id: 6549,
+        post_number: 1,
+        created_at: "2026-03-14T00:00:00.000Z",
+        username: "zenyas",
+        name: "Yaser",
+        cooked: "<p>Proposal body</p>",
+      },
+      rangeStartMs: startMs,
+    });
+
+    expect(item.isTopicOp).toBe(true);
+    expect(item.isNewTopicThisWeek).toBe(true);
+    expect(item.url).toContain("/t/laas/2401/1");
+  });
+
+  it("filters out low-signal replies", () => {
+    expect(
+      shouldKeepPostForDigest({
+        isTopicOp: false,
+        contentText: "Agree",
+        authorUsername: "random",
+        signalScore: 0,
+      })
+    ).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/news/forum.test.ts`
+Expected: FAIL with missing modules or missing exports.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+export function getCandidateTopicsForWindow(
+  topics: Array<{ created_at: string; last_posted_at: string }>,
+  window: { startMs: number; endMs: number }
+) {
+  return topics.filter((topic) => {
+    const createdAt = Date.parse(topic.created_at);
+    const lastPostedAt = Date.parse(topic.last_posted_at);
+    return (
+      (createdAt >= window.startMs && createdAt < window.endMs) ||
+      (lastPostedAt >= window.startMs && lastPostedAt < window.endMs)
+    );
+  });
+}
+
+export function stripCookedHtmlToText(cooked: string) {
+  return cooked.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+```
+
+Implement `normalizeTopicPostToSourceItem` and `shouldKeepPostForDigest` with the minimum logic required by the tests, then expand during later tasks.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/news/forum.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/news/forum.ts lib/news/filter.ts tests/news/forum.test.ts
+git commit -m "feat: add forum normalization and filtering utilities"
+```
+
+### Task 4: Add Convex schema for raw news items and weekly digests
+
+**Files:**
+- Modify: `convex/schema.ts`
+- Modify: `convex/_generated/*` (generated by codegen)
+- Test: `tests/news/schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import schema from "../../convex/schema";
+
+describe("news schema", () => {
+  it("exports a schema object", () => {
+    expect(schema).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/news/schema.test.ts`
+Expected: FAIL initially if import path or schema additions are not in place.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `newsSourceItems` and `newsDigests` tables to `convex/schema.ts`.
+
+```ts
+newsSourceItems: defineTable({
+  source: v.string(),
+  category: v.string(),
+  topicId: v.number(),
+  postId: v.number(),
+  topicTitle: v.string(),
+  topicSlug: v.string(),
+  url: v.string(),
+  authorUsername: v.string(),
+  authorName: v.optional(v.string()),
+  createdAtMs: v.number(),
+  weekKey: v.string(),
+  isTopicOp: v.boolean(),
+  isNewTopicThisWeek: v.boolean(),
+  contentText: v.string(),
+  rawJson: v.string(),
+  signalScore: v.number(),
+})
+  .index("by_weekKey", ["weekKey"])
+  .index("by_topicId", ["topicId"])
+  .index("by_source_and_weekKey", ["source", "weekKey"]),
+
+newsDigests: defineTable({
+  weekKey: v.string(),
+  rangeStartMs: v.number(),
+  rangeEndMs: v.number(),
+  status: v.string(),
+  title: v.string(),
+  summary: v.string(),
+  sections: v.array(
+    v.object({
+      title: v.string(),
+      bullets: v.array(v.string()),
+    })
+  ),
+  sourceCounts: v.object({
+    forumPosts: v.number(),
+    forumTopics: v.number(),
+  }),
+  model: v.string(),
+  promptVersion: v.string(),
+  generatedAtMs: v.number(),
+  errorMessage: v.optional(v.string()),
+})
+  .index("by_weekKey", ["weekKey"])
+  .index("by_generatedAtMs", ["generatedAtMs"]),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/news/schema.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run code generation**
+
+Run: `npx convex codegen`
+Expected: updated generated API/types.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add convex/schema.ts convex/_generated tests/news/schema.test.ts
+git commit -m "feat: add schema for weekly news digests"
+```
+
+### Task 5: Add OpenAI prompt and response parsing utilities with TDD
+
+**Files:**
+- Create: `lib/news/prompt.ts`
+- Create: `lib/news/openai.ts`
+- Test: `tests/news/openai.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildDigestPrompt } from "@/lib/news/prompt";
+import { parseDigestResponse } from "@/lib/news/openai";
+
+describe("news OpenAI helpers", () => {
+  it("builds a prompt that forbids outside knowledge", () => {
+    const prompt = buildDigestPrompt({
+      weekLabel: "Week of Mar 19, 2026",
+      sourceItems: [],
+    });
+
+    expect(prompt).toContain("Only use the supplied forum content");
+  });
+
+  it("parses structured digest output", () => {
+    const parsed = parseDigestResponse({
+      title: "Weekly Pyth Digest",
+      summary: "Quiet week.",
+      sections: [{ title: "Proposal activity", bullets: ["No new proposals."] }],
+    });
+
+    expect(parsed.sections).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/news/openai.test.ts`
+Expected: FAIL with missing helpers.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implement:
+- `buildDigestPrompt`
+- `getDigestResponseSchema`
+- `parseDigestResponse`
+
+Keep the schema minimal:
+
+```ts
+type DigestSection = {
+  title: string;
+  bullets: string[];
+};
+
+type DigestOutput = {
+  title: string;
+  summary: string;
+  sections: DigestSection[];
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- tests/news/openai.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/news/prompt.ts lib/news/openai.ts tests/news/openai.test.ts
+git commit -m "feat: add OpenAI prompt and parsing utilities for news digest"
+```
+
+### Task 6: Implement Convex news pipeline for weekly ingestion and digest generation
+
+**Files:**
+- Create: `convex/news.ts`
+- Modify: `convex/crons.ts`
+- Test: `tests/news/news-pipeline.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create focused tests for pure helpers extracted from the pipeline:
+- selecting candidate topics from category JSON
+- selecting only posts inside the digest window
+- computing source counts
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  getDigestWindowPosts,
+  summarizeSourceCounts,
+} from "@/lib/news/forum";
+
+describe("news pipeline helpers", () => {
+  it("keeps only posts inside the weekly window", () => {
+    const posts = [
+      { created_at: "2026-03-11T23:59:59.000Z" },
+      { created_at: "2026-03-12T00:00:00.000Z" },
+      { created_at: "2026-03-18T23:59:59.000Z" },
+    ];
+
+    expect(
+      getDigestWindowPosts(posts, {
+        startMs: Date.parse("2026-03-12T00:00:00.000Z"),
+        endMs: Date.parse("2026-03-19T00:00:00.000Z"),
+      })
+    ).toHaveLength(2);
+  });
+
+  it("summarizes source counts", () => {
+    const counts = summarizeSourceCounts([
+      { topicId: 1 },
+      { topicId: 1 },
+      { topicId: 2 },
+    ]);
+
+    expect(counts.forumPosts).toBe(3);
+    expect(counts.forumTopics).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/news/news-pipeline.test.ts`
+Expected: FAIL until helpers and pipeline exports exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `convex/news.ts`, implement:
+- `upsertSourceItems` internal mutation
+- `saveDigest` internal mutation
+- `getLatestDigest` query
+- `listDigests` query
+- `triggerDigestGeneration` mutation
+- `generateWeeklyDigest` internal action
+
+Pipeline details:
+- Fetch `https://forum.pyth.network/c/proposals/7/l/latest.json`
+- Keep topics with `created_at` or `last_posted_at` in the window
+- Fetch each topic JSON at `/t/{slug}/{id}.json`
+- Keep only posts whose `created_at` is in the weekly window
+- Normalize and filter posts
+- Call OpenAI with structured output
+- Save digest keyed by `weekKey`
+- Skip rerun when a completed digest already exists for the same `weekKey`, unless explicitly forced
+
+- [ ] **Step 4: Update cron**
+
+In `convex/crons.ts`, add a weekly Thursday job:
+
+```ts
+crons.weekly(
+  "generate weekly pyth digest",
+  { dayOfWeek: "thursday", hourUTC: 1, minuteUTC: 0 },
+  internal.news.generateWeeklyDigest,
+  {}
+);
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `npm run test -- tests/news/news-pipeline.test.ts`
+Expected: PASS for helper coverage.
+
+- [ ] **Step 6: Run code generation**
+
+Run: `npx convex codegen`
+Expected: API entries for `news`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add convex/news.ts convex/crons.ts convex/_generated lib/news tests/news/news-pipeline.test.ts
+git commit -m "feat: add weekly forum digest pipeline"
+```
+
+### Task 7: Add manual trigger support and failure handling
+
+**Files:**
+- Modify: `convex/news.ts`
+- Test: `tests/news/news-actions.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add pure helper tests for:
+- digest status transitions
+- idempotent `weekKey` save behavior
+- fallback error payload formatting
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- tests/news/news-actions.test.ts`
+Expected: FAIL until helper behavior exists.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Ensure:
+- failed generations save a `newsDigests` row with `status: "failed"`
+- reruns can be forced from a mutation argument
+- success and failure both store `generatedAtMs`
+- error messages are trimmed to a safe length
+
+- [ ] **Step 4: Run tests to verify it passes**
+
+Run: `npm run test -- tests/news/news-actions.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add convex/news.ts tests/news/news-actions.test.ts
+git commit -m "feat: add robust failure handling for news generation"
+```
+
+### Task 8: Build the `/news` page shell aligned with existing subpages
+
+**Files:**
+- Create: `app/news/page.tsx`
+- Create: `components/news/news-hero.tsx`
+- Create: `components/news/news-digest-card.tsx`
+- Create: `components/news/news-archive.tsx`
+- Modify: `components/sidebar.tsx`
+
+- [ ] **Step 1: Write the failing test or static acceptance checklist**
+
+Use a lightweight UI acceptance checklist if component tests are not already present:
+- `/news` appears in the sidebar
+- page uses the same width/spacing rhythm as `/reserve`
+- hero uses rounded, gradient-backed panel styling consistent with current subpages
+- latest digest appears above archive cards
+
+- [ ] **Step 2: Implement the page shell**
+
+`app/news/page.tsx` should:
+- be a client component if using `useQuery`
+- call `useQuery(api.news.getLatestDigest, {})`
+- call `useQuery(api.news.listDigests, { limit: 12 })`
+- render loading and empty states with existing card styling
+
+`components/news/news-hero.tsx` should render:
+- title: `Weekly Pyth Digest`
+- description
+- badges for week label and source counts
+
+`components/news/news-digest-card.tsx` should render:
+- digest summary
+- section cards or blocks
+- generated timestamp
+
+`components/news/news-archive.tsx` should render:
+- compact archive cards below the main digest
+- clickable list or expandable items, depending on the simplest implementation path
+
+Update `components/sidebar.tsx`:
+- add `{ href: "/news", label: "News", icon: Newspaper }`
+
+- [ ] **Step 3: Match existing design language**
+
+Follow patterns from `/reserve`:
+- rounded corners in the 24px to 30px range
+- subdued borders and translucent gradients
+- mobile-first stacking
+- no blog-style typography overhaul
+
+- [ ] **Step 4: Run the app and visually verify**
+
+Run: `npm run dev`
+Check:
+- sidebar link appears and highlights correctly
+- `/news` loads with loading, empty, and populated states
+- design feels like a sibling to `/reserve`, not a separate microsite
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/news/page.tsx components/news components/sidebar.tsx
+git commit -m "feat: add news page and archive UI"
+```
+
+### Task 9: Add metadata, polish, and empty-state copy
+
+**Files:**
+- Modify: `app/news/page.tsx`
+- Modify: `app/layout.tsx` (only if page metadata strategy needs central updates)
+- Modify: `components/news/news-hero.tsx`
+- Modify: `components/news/news-digest-card.tsx`
+
+- [ ] **Step 1: Add empty and quiet-week UX**
+
+Support these states:
+- no digest yet
+- failed digest last run
+- quiet week with low activity but successful generation
+
+Example quiet-week copy:
+- `Quiet week on Pyth proposals. No major new proposal activity, but the archive remains available below.`
+
+- [ ] **Step 2: Add page metadata**
+
+Use page-level metadata in `app/news/page.tsx` if possible:
+- title: `Weekly Pyth Digest | Pyth Dashboard`
+- description: `Weekly digest of Pyth proposal activity and notable forum discussion`
+
+- [ ] **Step 3: Verify visual polish**
+
+Check:
+- line lengths stay readable inside cards
+- archive cards do not crowd mobile layouts
+- metadata badges do not wrap awkwardly
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/news/page.tsx app/layout.tsx components/news
+git commit -m "feat: polish weekly digest states and metadata"
+```
+
+### Task 10: Verify end-to-end behavior before completion
+
+**Files:**
+- No new files required
+
+- [ ] **Step 1: Run the relevant tests**
+
+Run: `npm run test -- tests/news`
+Expected: PASS.
+
+- [ ] **Step 2: Run static verification**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Run app verification**
+
+Run: `npm run dev`
+Expected:
+- app boots
+- `/news` renders
+- Convex queries compile
+
+- [ ] **Step 4: Manual smoke test the pipeline**
+
+Use the manual mutation trigger for a test run in dev.
+Expected:
+- source items persist
+- digest row persists
+- `/news` shows latest digest and archive
+
+- [ ] **Step 5: Review for YAGNI**
+
+Confirm that V1 does not include:
+- X integration
+- markdown rendering dependency
+- forum write-back/posting
+- multiple categories beyond Proposals unless explicitly added during implementation
+
+- [ ] **Step 6: Commit final verification changes**
+
+```bash
+git add .
+git commit -m "feat: ship weekly pyth digest"
+```
+
+## Notes For Implementation
+
+- Use only the live Pyth forum Proposals feed for V1:
+  - `https://forum.pyth.network/c/proposals/7/l/latest.json`
+- Topic JSON should be fetched per thread:
+  - `https://forum.pyth.network/t/{slug}/{topicId}.json`
+- Summaries must be based only on posts created during the weekly window.
+- Older threads may appear in the digest only when they contain meaningful new posts inside the weekly window.
+- Keep rendering structured JSON in the UI rather than storing raw markdown as the primary format.
+- Match the page design to the existing subpage language in `app/reserve/page.tsx` and `components/ui/card.tsx`.
+
+Plan complete and saved to `docs/plans/2026-03-18-news-digest-implementation.md`. Ready to execute.

--- a/lib/news/filter.ts
+++ b/lib/news/filter.ts
@@ -1,0 +1,19 @@
+export function shouldKeepPostForDigest(input: {
+  isTopicOp: boolean;
+  isNewTopicThisWeek?: boolean;
+  contentText: string;
+  authorUsername: string;
+  signalScore: number;
+}) {
+  if (input.isTopicOp) {
+    return true;
+  }
+
+  const normalizedText = input.contentText.trim();
+  const minLength = input.isNewTopicThisWeek ? 24 : 18;
+  if (normalizedText.length < minLength) {
+    return false;
+  }
+
+  return input.signalScore > 0;
+}

--- a/lib/news/forum.ts
+++ b/lib/news/forum.ts
@@ -1,0 +1,97 @@
+type TopicLike = {
+  id: number;
+  slug: string;
+  title: string;
+  created_at: string;
+  last_posted_at: string;
+};
+
+type PostLike = {
+  id: number;
+  post_number: number;
+  created_at: string;
+  username: string;
+  name?: string | null;
+  cooked: string;
+};
+
+type Window = {
+  startMs: number;
+  endMs: number;
+};
+
+export function getCandidateTopicsForWindow(
+  topics: TopicLike[],
+  { startMs, endMs }: Window
+) {
+  return topics.filter((topic) => {
+    const createdAtMs = Date.parse(topic.created_at);
+    const lastPostedAtMs = Date.parse(topic.last_posted_at);
+
+    return (
+      (createdAtMs >= startMs && createdAtMs < endMs) ||
+      (lastPostedAtMs >= startMs && lastPostedAtMs < endMs)
+    );
+  });
+}
+
+export function stripCookedHtmlToText(cooked: string) {
+  return cooked.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+export function normalizeTopicPostToSourceItem({
+  category,
+  weekKey,
+  topic,
+  post,
+  rangeStartMs,
+}: {
+  category: string;
+  weekKey: string;
+  topic: Pick<TopicLike, "id" | "slug" | "title" | "created_at">;
+  post: PostLike;
+  rangeStartMs: number;
+}) {
+  const createdAtMs = Date.parse(post.created_at);
+  const topicCreatedAtMs = Date.parse(topic.created_at);
+  const contentText = stripCookedHtmlToText(post.cooked);
+
+  return {
+    source: "forum",
+    category,
+    topicId: topic.id,
+    postId: post.id,
+    topicTitle: topic.title,
+    topicSlug: topic.slug,
+    url: `https://forum.pyth.network/t/${topic.slug}/${topic.id}/${post.post_number}`,
+    authorUsername: post.username,
+    authorName: post.name ?? undefined,
+    createdAtMs,
+    weekKey,
+    isTopicOp: post.post_number === 1,
+    isNewTopicThisWeek: topicCreatedAtMs >= rangeStartMs,
+    contentText,
+    rawJson: JSON.stringify(post),
+    signalScore: Math.min(contentText.length, 1000),
+  };
+}
+
+export function getDigestWindowPosts<
+  T extends {
+    created_at: string;
+  },
+>(posts: T[], { startMs, endMs }: Window) {
+  return posts.filter((post) => {
+    const createdAtMs = Date.parse(post.created_at);
+    return createdAtMs >= startMs && createdAtMs < endMs;
+  });
+}
+
+export function summarizeSourceCounts(
+  items: Array<{ topicId: number; category?: string }>
+) {
+  return {
+    forumPosts: items.length,
+    forumTopics: new Set(items.map((item) => item.topicId)).size,
+  };
+}

--- a/lib/news/openai.ts
+++ b/lib/news/openai.ts
@@ -1,0 +1,90 @@
+export type DigestSectionSource = {
+  label: string;
+  url: string;
+};
+
+export type DigestSection = {
+  title: string;
+  summary?: string;
+  bullets?: string[];
+  sources?: DigestSectionSource[];
+};
+
+export type DigestOutput = {
+  title: string;
+  summary: string;
+  sections: DigestSection[];
+};
+
+function cleanBulletText(text: string) {
+  return text
+    .replace(/\s*\(Sources?:[\s\S]*$/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isSourceOnlyBullet(text: string) {
+  return /^sources?:\s+/i.test(text.trim());
+}
+
+function cleanSummaryText(text: string) {
+  return text
+    .replace(/\s*\(Sources?:[\s\S]*$/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function parseDigestResponse(response: DigestOutput) {
+  return {
+    title: response.title,
+    summary: response.summary,
+    sections: response.sections.map((section) => ({
+      title: section.title,
+      summary:
+        "summary" in section && typeof section.summary === "string"
+          ? cleanSummaryText(section.summary)
+          : (section.bullets ?? [])
+              .filter((bullet) => !isSourceOnlyBullet(bullet))
+              .map(cleanBulletText)
+              .filter(Boolean)
+              .join(" "),
+      sources: section.sources ?? [],
+    })),
+  };
+}
+
+export function getDigestResponseSchema() {
+  return {
+    type: "object",
+    additionalProperties: false,
+    required: ["title", "summary", "sections"],
+    properties: {
+      title: { type: "string" },
+      summary: { type: "string" },
+      sections: {
+        type: "array",
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["title", "summary", "sources"],
+          properties: {
+            title: { type: "string" },
+            summary: { type: "string" },
+            sources: {
+              type: "array",
+              items: {
+                type: "object",
+                additionalProperties: false,
+                required: ["label", "url"],
+                properties: {
+                  label: { type: "string" },
+                  url: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/lib/news/prompt.ts
+++ b/lib/news/prompt.ts
@@ -1,0 +1,38 @@
+type PromptSourceItem = {
+  topicTitle?: string;
+  authorUsername?: string;
+  contentText?: string;
+  url?: string;
+};
+
+export function buildDigestPrompt(input: {
+  weekLabel: string;
+  sourceItems: PromptSourceItem[];
+}) {
+  const items =
+    input.sourceItems.length === 0
+      ? "No source items were collected for this week."
+      : input.sourceItems
+          .map((item, index) => {
+            return [
+              `Source ${index + 1}`,
+              `Title: ${item.topicTitle ?? "Untitled"}`,
+              `Author: ${item.authorUsername ?? "unknown"}`,
+              `URL: ${item.url ?? "missing"}`,
+              `Content: ${item.contentText ?? ""}`,
+            ].join("\n");
+          })
+          .join("\n\n");
+
+  return [
+    `Generate a weekly Pyth digest for ${input.weekLabel}.`,
+    "Only use the supplied forum content.",
+    "Do not use outside knowledge or speculate.",
+    "Return a concise factual digest with sections.",
+    "Every section must include source links taken directly from the supplied URLs.",
+    "Write each section as clean prose, not bullets.",
+    "Do not put URLs or source references in the summary text.",
+    "",
+    items,
+  ].join("\n");
+}

--- a/lib/news/types.ts
+++ b/lib/news/types.ts
@@ -1,0 +1,30 @@
+export type NewsDigestSectionSource = {
+  label: string;
+  url: string;
+};
+
+export type NewsDigestSection = {
+  title: string;
+  summary: string;
+  bullets?: string[];
+  sources?: NewsDigestSectionSource[];
+};
+
+export type NewsDigest = {
+  _id?: string;
+  weekKey: string;
+  rangeStartMs: number;
+  rangeEndMs: number;
+  status: string;
+  title: string;
+  summary: string;
+  sections: NewsDigestSection[];
+  sourceCounts: {
+    forumPosts: number;
+    forumTopics: number;
+  };
+  model: string;
+  promptVersion: string;
+  generatedAtMs: number;
+  errorMessage?: string;
+};

--- a/lib/news/week.ts
+++ b/lib/news/week.ts
@@ -1,0 +1,23 @@
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function buildDigestWeekWindow(endMs: number) {
+  return {
+    startMs: endMs - WEEK_MS,
+    endMs,
+  };
+}
+
+export function formatWeekKey(endMs: number) {
+  return new Date(endMs).toISOString().slice(0, 10);
+}
+
+export function formatWeekLabel(endMs: number) {
+  const formatted = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(endMs));
+
+  return `Week of ${formatted}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "eslint-config-next": "^16.1.1",
         "tailwindcss": "^4.1.8",
         "tw-animate-css": "^1.3.4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -399,20 +400,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
-      "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.0.2",
+        "@emnapi/wasi-threads": "1.2.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -420,10 +422,11 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
-      "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1554,10 +1557,11 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
@@ -1818,6 +1822,26 @@
       "dev": true,
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
+      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
+      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -2386,6 +2410,296 @@
         }
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
+      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
+      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2770,6 +3084,13 @@
         }
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@streamparser/json": {
       "version": "0.0.22",
       "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.22.tgz",
@@ -3063,6 +3384,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -3124,6 +3456,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3737,6 +4076,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -3986,6 +4438,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -4358,6 +4820,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -5062,6 +5534,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5612,6 +6091,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5625,6 +6114,16 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/eyes": {
       "version": "0.1.8",
@@ -5839,6 +6338,21 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6858,6 +7372,27 @@
         "lightningcss-win32-x64-msvc": "1.30.1"
       }
     },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
@@ -7142,12 +7677,13 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7540,6 +8076,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7645,6 +8192,13 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7673,9 +8227,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -7691,6 +8245,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
@@ -8072,6 +8627,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
+      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.115.0",
+        "@rolldown/pluginutils": "1.0.0-rc.9"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+      }
+    },
     "node_modules/rpc-websockets": {
       "version": "7.11.0",
       "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.0.tgz",
@@ -8428,6 +9017,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -8450,6 +9046,20 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -8739,6 +9349,23 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8786,6 +9413,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -9153,6 +9790,433 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
+      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/runtime": "0.115.0",
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.9",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.0.0-alpha.31",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -9265,6 +10329,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "rebuild": "npm rebuild"
   },
   "dependencies": {
@@ -45,7 +47,8 @@
     "eslint-config-next": "^16.1.1",
     "tailwindcss": "^4.1.8",
     "tw-animate-css": "^1.3.4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.0"
   },
   "overrides": {
     "@solana/web3.js": "^1.98.4",

--- a/tests/news/forum.test.ts
+++ b/tests/news/forum.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  getCandidateTopicsForWindow,
+  normalizeTopicPostToSourceItem,
+  stripCookedHtmlToText,
+  getDigestWindowPosts,
+  summarizeSourceCounts,
+} from "@/lib/news/forum";
+import { shouldKeepPostForDigest } from "@/lib/news/filter";
+
+describe("forum news utilities", () => {
+  const startMs = Date.parse("2026-03-12T00:00:00.000Z");
+  const endMs = Date.parse("2026-03-19T00:00:00.000Z");
+
+  it("keeps topics created or updated inside the digest window", () => {
+    const topics = [
+      {
+        id: 1,
+        slug: "fresh-proposal",
+        title: "Fresh Proposal",
+        created_at: "2026-03-14T12:00:00.000Z",
+        last_posted_at: "2026-03-14T12:00:00.000Z",
+      },
+      {
+        id: 2,
+        slug: "older-thread",
+        title: "Older Thread",
+        created_at: "2026-03-01T12:00:00.000Z",
+        last_posted_at: "2026-03-16T12:00:00.000Z",
+      },
+      {
+        id: 3,
+        slug: "stale-thread",
+        title: "Stale Thread",
+        created_at: "2026-03-01T12:00:00.000Z",
+        last_posted_at: "2026-03-05T12:00:00.000Z",
+      },
+    ];
+
+    expect(getCandidateTopicsForWindow(topics, { startMs, endMs })).toHaveLength(
+      2
+    );
+  });
+
+  it("converts cooked HTML into text", () => {
+    expect(stripCookedHtmlToText("<p>Hello <strong>world</strong></p>")).toBe(
+      "Hello world"
+    );
+  });
+
+  it("marks OP posts for new topics correctly", () => {
+    const item = normalizeTopicPostToSourceItem({
+      category: "proposals",
+      weekKey: "2026-03-19",
+      topic: {
+        id: 2401,
+        slug: "laas",
+        title: "LaaS",
+        created_at: "2026-03-14T00:00:00.000Z",
+      },
+      post: {
+        id: 6549,
+        post_number: 1,
+        created_at: "2026-03-14T00:00:00.000Z",
+        username: "zenyas",
+        name: "Yaser",
+        cooked: "<p>Proposal body</p>",
+      },
+      rangeStartMs: startMs,
+    });
+
+    expect(item.isTopicOp).toBe(true);
+    expect(item.isNewTopicThisWeek).toBe(true);
+    expect(item.url).toContain("/t/laas/2401/1");
+  });
+
+  it("filters out low-signal replies", () => {
+    expect(
+      shouldKeepPostForDigest({
+        isTopicOp: false,
+        isNewTopicThisWeek: false,
+        contentText: "Agree",
+        authorUsername: "random",
+        signalScore: 0,
+      })
+    ).toBe(false);
+  });
+
+  it("keeps substantive replies for older active threads with a lower threshold", () => {
+    expect(
+      shouldKeepPostForDigest({
+        isTopicOp: false,
+        isNewTopicThisWeek: false,
+        contentText: "30 day grace is right",
+        authorUsername: "community-member",
+        signalScore: 24,
+      })
+    ).toBe(true);
+  });
+
+  it("keeps only posts inside the weekly window", () => {
+    const posts = [
+      { created_at: "2026-03-11T23:59:59.000Z" },
+      { created_at: "2026-03-12T00:00:00.000Z" },
+      { created_at: "2026-03-18T23:59:59.000Z" },
+    ];
+
+    expect(getDigestWindowPosts(posts, { startMs, endMs })).toHaveLength(2);
+  });
+
+  it("summarizes source counts", () => {
+    const counts = summarizeSourceCounts([
+      { topicId: 1, category: "proposals" },
+      { topicId: 1, category: "proposals" },
+      { topicId: 2, category: "ideas-bank" },
+    ]);
+
+    expect(counts.forumPosts).toBe(3);
+    expect(counts.forumTopics).toBe(2);
+  });
+});

--- a/tests/news/openai.test.ts
+++ b/tests/news/openai.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { buildDigestPrompt } from "@/lib/news/prompt";
+import { parseDigestResponse } from "@/lib/news/openai";
+
+describe("news OpenAI helpers", () => {
+  it("builds a prompt that forbids outside knowledge", () => {
+    const prompt = buildDigestPrompt({
+      weekLabel: "Week of Mar 19, 2026",
+      sourceItems: [
+        {
+          topicTitle: "LaaS",
+          authorUsername: "zenyas",
+          url: "https://forum.pyth.network/t/laas/2401/1",
+          contentText: "Proposal body",
+        },
+      ],
+    });
+
+    expect(prompt).toContain("Only use the supplied forum content");
+    expect(prompt).toContain("Every section must include source links");
+    expect(prompt).toContain("Write each section as clean prose, not bullets");
+    expect(prompt).toContain("Do not put URLs or source references in the summary text");
+  });
+
+  it("parses structured digest output", () => {
+    const parsed = parseDigestResponse({
+      title: "Weekly Pyth Digest",
+      summary: "Quiet week.",
+      sections: [
+        {
+          title: "Proposal activity",
+          summary:
+            "No new proposals. (Sources: [1](https://forum.pyth.network/t/example/1))",
+          sources: [
+            {
+              label: "Forum thread",
+              url: "https://forum.pyth.network/t/example/1",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(parsed.sections).toHaveLength(1);
+    expect(parsed.sections[0].sources).toHaveLength(1);
+    expect(parsed.sections[0].summary).toBe("No new proposals.");
+  });
+
+  it("can normalize legacy bullet sections into a prose summary", () => {
+    const parsed = parseDigestResponse({
+      title: "Weekly Pyth Digest",
+      summary: "Quiet week.",
+      sections: [
+        {
+          title: "Proposal activity",
+          bullets: ["First point.", "Second point."],
+          sources: [],
+        },
+      ],
+    });
+
+    expect(parsed.sections[0].summary).toBe("First point. Second point.");
+  });
+});

--- a/tests/news/schema.test.ts
+++ b/tests/news/schema.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import schema from "../../convex/schema";
+
+describe("news schema", () => {
+  it("exports a schema object", () => {
+    expect(schema).toBeTruthy();
+  });
+});

--- a/tests/news/smoke.test.ts
+++ b/tests/news/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from "vitest";
+
+describe("news test harness", () => {
+  it("runs vitest", () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/tests/news/week.test.ts
+++ b/tests/news/week.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDigestWeekWindow,
+  formatWeekKey,
+  formatWeekLabel,
+} from "@/lib/news/week";
+
+describe("news week helpers", () => {
+  it("builds a Thursday-to-Thursday UTC window", () => {
+    const end = Date.parse("2026-03-19T00:00:00.000Z");
+    const window = buildDigestWeekWindow(end);
+
+    expect(window.startMs).toBe(Date.parse("2026-03-12T00:00:00.000Z"));
+    expect(window.endMs).toBe(end);
+  });
+
+  it("formats a stable week key", () => {
+    expect(formatWeekKey(Date.parse("2026-03-19T00:00:00.000Z"))).toBe(
+      "2026-03-19"
+    );
+  });
+
+  it("formats a user-facing label", () => {
+    expect(formatWeekLabel(Date.parse("2026-03-19T00:00:00.000Z"))).toBe(
+      "Week of Mar 19, 2026"
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a new `/news` page with latest digest, archive selection, and beta-tagged hero UI aligned with existing subpages
- build a Convex-backed weekly digest pipeline for Pyth forum `Proposals` and `Ideas Bank`, including schema, cron, source item ingestion, filtering, and OpenAI summarization
- add typed news utilities for week windows, forum normalization, prompt/response handling, and digest rendering
- update navigation to expose the new news page
- add Vitest coverage for forum ingestion, week logic, schema handling, OpenAI parsing, and smoke checks

## Testing
- `npm run test -- tests/news/forum.test.ts tests/news/openai.test.ts tests/news/schema.test.ts tests/news/smoke.test.ts tests/news/week.test.ts`
- `npx tsc --noEmit`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new News page featuring weekly forum digests with archive browsing and source tracking
  * Digests display related sources, topic counts, and generation timestamps

* **Style**
  * Updated Beta badge styling with a new cyan-themed design

* **Tests**
  * Added comprehensive test coverage for digest generation utilities and formatting

* **Chores**
  * Added testing framework and npm test scripts
  * Added implementation documentation for digest architecture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->