### PR TITLE
Fix wallet refresh UX and staking account discovery errors

### DIFF
--- a/action/priceActions.ts
+++ b/action/priceActions.ts
@@ -49,43 +49,38 @@ async function getPriceFromHermes(priceId: string): Promise<number> {
 }
 
 /**
- * Fetches 24h price change from CoinGecko API
- * This is a fallback method to get historical price data
+ * Fetches the price of an asset from Hermes at a specific Unix timestamp.
+ * Returns 0 if unavailable.
  */
-async function get24hChangeFromCoinGecko(
-  coinId: string
-): Promise<{ change24h: number; change24hValue: number }> {
+async function getPriceFromHermesAt(
+  priceId: string,
+  unixTimestamp: number
+): Promise<number> {
   try {
     const response = await fetch(
-      `https://api.coingecko.com/api/v3/simple/price?ids=${coinId}&vs_currencies=usd&include_24hr_change=true`,
-      {
-        headers: {
-          Accept: "application/json",
-        },
-        next: { revalidate: 60 }, // Cache for 60 seconds
-      }
+      `https://hermes.pyth.network/v2/updates/price/${unixTimestamp}?ids%5B%5D=${priceId}`,
+      { headers: { Accept: "application/json", "User-Agent": "PythBoard/1.0" } }
     );
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-
+    if (!response.ok) return 0;
     const data = await response.json();
-    const coinData = data[coinId];
-
-    if (coinData && coinData.usd && coinData.usd_24h_change !== undefined) {
-      const change24h = coinData.usd_24h_change;
-      const price = coinData.usd;
-      const change24hValue = (price * change24h) / 100;
-
-      return { change24h, change24hValue };
-    }
-
-    return { change24h: 0, change24hValue: 0 };
-  } catch (error) {
-    console.error(`Error fetching 24h change for ${coinId}:`, error);
-    return { change24h: 0, change24hValue: 0 };
+    if (!data.parsed?.[0]?.price) return 0;
+    return Number(data.parsed[0].price.price) * 1e-8;
+  } catch {
+    return 0;
   }
+}
+
+/**
+ * Computes 24h change from current and past prices.
+ */
+function compute24hChange(
+  currentPrice: number,
+  pastPrice: number
+): { change24h: number; change24hValue: number } {
+  if (!pastPrice) return { change24h: 0, change24hValue: 0 };
+  const change24h = ((currentPrice - pastPrice) / pastPrice) * 100;
+  const change24hValue = currentPrice - pastPrice;
+  return { change24h, change24hValue };
 }
 
 /**
@@ -98,13 +93,17 @@ export async function getRealtimePrices(): Promise<{
   const SOL_PRICE_ID = "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d";
   const PYTH_PRICE_ID = "0bbf28e9a841a1cc788f6a361b17ca072d0ea3098a1e5df1c3922d06719579ff";
 
-  // Fetch current prices from Hermes API
-  const [solPrice, pythPrice, solChange, pythChange] = await Promise.all([
+  const timestamp24hAgo = Math.floor(Date.now() / 1000) - 86400;
+
+  const [solPrice, pythPrice, sol24hAgo, pyth24hAgo] = await Promise.all([
     getPriceFromHermes(SOL_PRICE_ID),
     getPriceFromHermes(PYTH_PRICE_ID),
-    get24hChangeFromCoinGecko("solana"),
-    get24hChangeFromCoinGecko("pyth-network"),
+    getPriceFromHermesAt(SOL_PRICE_ID, timestamp24hAgo),
+    getPriceFromHermesAt(PYTH_PRICE_ID, timestamp24hAgo),
   ]);
+
+  const solChange = compute24hChange(solPrice, sol24hAgo);
+  const pythChange = compute24hChange(pythPrice, pyth24hAgo);
 
   return {
     sol: {

--- a/action/pythActions.ts
+++ b/action/pythActions.ts
@@ -82,12 +82,10 @@ export async function getOISStakingInfo(
     throw new Error(`Failed to create Pyth staking client: ${errorMessage}`);
   }
 
-  const { client: responsiveClient, stakeAccount } = await discoverStakeAccount(
-    client,
-    walletPublicKey
-  );
-
   try {
+    const { client: responsiveClient, stakeAccount } =
+      await discoverStakeAccount(client, walletPublicKey);
+
     // Fetch everything in one parallel batch.
     // poolData is fetched once and reused for both generalStats and publisherPoolData.
     // getClaimableRewards runs in parallel with the rest; failures fall back to 0.
@@ -183,7 +181,16 @@ export async function getOISStakingInfo(
       error instanceof Error ? error.message : "Unknown error";
 
     // Provide more specific error messages
-    if (errorMessage.includes("Account does not exist")) {
+    if (errorMessage.startsWith("No staking account found")) {
+      throw new Error("No staking account found for this wallet");
+    } else if (
+      errorMessage.includes("discover staking account") &&
+      errorMessage.includes("timed out")
+    ) {
+      throw new Error(
+        "RPC timeout: Unable to discover staking account. Please try again later."
+      );
+    } else if (errorMessage.includes("Account does not exist")) {
       throw new Error("Staking account does not exist or has no positions");
     } else if (
       errorMessage.includes("Slot") &&

--- a/action/pythActions.ts
+++ b/action/pythActions.ts
@@ -456,6 +456,111 @@ async function getPublisherPoolData(client: PythStakingClient) {
 }
 
 /**
+ * Refreshes staking information for a wallet using a known staking address.
+ * Skips account discovery — use this on reload when stakingAddress is already stored.
+ * @param {string} walletAddress - The public key of the wallet.
+ * @param {string} stakingAddress - The known staking account address.
+ * @returns {Promise<{ info: PythStakingInfo; stakingAddress: string }>}
+ */
+export async function refreshOISStakingInfo(
+  walletAddress: string,
+  stakingAddress: string
+): Promise<{ info: PythStakingInfo; stakingAddress: string }> {
+  if (!walletAddress) throw new Error("Wallet address is required");
+  if (!stakingAddress) throw new Error("Staking address is required");
+  if (!isValidSolanaAddress(walletAddress))
+    throw new Error("Invalid wallet address format");
+  if (!isValidSolanaAddress(stakingAddress))
+    throw new Error("Invalid staking address format");
+
+  const walletPublicKey = new PublicKey(walletAddress);
+  const stakeAccount = new PublicKey(stakingAddress);
+
+  // Race all RPC endpoints; the first to respond wins
+  const clients = RPC_ENDPOINTS.map((_, index) =>
+    createPythStakingClientWithFallback(walletPublicKey, index)
+  );
+
+  const responsiveClient = await Promise.any(
+    clients.map(async (c) => {
+      // Lightweight probe: getTargetAccount is a global read, not wallet-specific
+      await c.getTargetAccount();
+      return c;
+    })
+  ).catch(() => clients[0]); // fall back to primary if all fail
+
+  const [rewards, positions, targetAccount, poolData, rewardCustodyAccount] =
+    await Promise.all([
+      getClaimableRewards(responsiveClient, stakeAccount).catch(() => ({
+        totalRewards: 0n,
+      })),
+      responsiveClient.getStakeAccountPositions(stakeAccount),
+      responsiveClient.getTargetAccount(),
+      responsiveClient.getPoolDataAccount(),
+      responsiveClient.getRewardCustodyAccount(),
+    ]);
+
+  const generalStats: PythGeneralStats = {
+    totalGovernance:
+      Number(targetAccount.locked + targetAccount.deltaLocked) * 1e-6,
+    totalStaked:
+      Number(
+        sumDelegations(poolData.delState) +
+          sumDelegations(poolData.selfDelState)
+      ) * 1e-6,
+    rewardsDistributed:
+      Number(
+        poolData.claimableRewards +
+          INITIAL_REWARD_POOL_SIZE -
+          rewardCustodyAccount.amount
+      ) * 1e-6,
+  };
+
+  const publisherPoolData = extractPublisherData(poolData).map(
+    ({ totalDelegation, totalDelegationDelta, pubkey, apyHistory }) => ({
+      totalDelegation,
+      totalDelegationDelta,
+      pubkey: pubkey.toBase58(),
+      apy: apyHistory[apyHistory.length - 1]?.apy ?? 0,
+    })
+  );
+
+  const claimableRewards = Number(rewards?.totalRewards || 0n) * 1e-6;
+
+  const StakeForEachPublisher: MyPublisherInfo[] = positions.data.positions
+    .map((p) => {
+      const publisher = p.targetWithParameters.integrityPool?.publisher;
+      if (!publisher) return null;
+      const key = String(publisher);
+      const publisherData = publisherPoolData.find((d) => d.pubkey === key);
+      return {
+        publisherKey: key,
+        stakedAmount: Number(p.amount) * 1e-6,
+        apy: publisherData?.apy ?? 0,
+        rewards: 0,
+      };
+    })
+    .filter((p): p is MyPublisherInfo => p !== null);
+
+  const totalStakedPyth = StakeForEachPublisher.reduce(
+    (acc, p) => acc + p.stakedAmount,
+    0
+  );
+
+  StakeForEachPublisher.forEach((p) => {
+    p.rewards =
+      totalStakedPyth > 0 && claimableRewards > 0
+        ? (p.stakedAmount / totalStakedPyth) * claimableRewards
+        : 0;
+  });
+
+  return {
+    info: { StakeForEachPublisher, totalStakedPyth, claimableRewards, generalStats },
+    stakingAddress,
+  };
+}
+
+/**
  * Fetches the latest Pyth price for a specific asset.
  * @returns {Promise<number>} - A promise that resolves to the latest Pyth price in base units.
  * @throws {Error} - Throws an error if the fetch operation fails or if the response is not ok.

--- a/action/pythActions.ts
+++ b/action/pythActions.ts
@@ -475,29 +475,35 @@ export async function refreshOISStakingInfo(
 
   const walletPublicKey = new PublicKey(walletAddress);
   const stakeAccount = new PublicKey(stakingAddress);
+  let lastError = "Unknown error";
 
-  // Race all RPC endpoints; the first to respond wins
-  const clients = RPC_ENDPOINTS.map((_, index) =>
-    createPythStakingClientWithFallback(walletPublicKey, index)
-  );
+  for (let index = 0; index < RPC_ENDPOINTS.length; index++) {
+    const client = createPythStakingClientWithFallback(walletPublicKey, index);
 
-  const responsiveClient = await Promise.any(
-    clients.map(async (c) => {
-      // Lightweight probe: getTargetAccount is a global read, not wallet-specific
-      await c.getTargetAccount();
-      return c;
-    })
-  ).catch(() => clients[0]); // fall back to primary if all fail
+    try {
+      return await fetchStakingInfoForAccount(client, stakeAccount, stakingAddress);
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : "Unknown error";
+    }
+  }
 
+  throw new Error(`Failed to refresh staking information: ${lastError}`);
+}
+
+async function fetchStakingInfoForAccount(
+  client: PythStakingClient,
+  stakeAccount: PublicKey,
+  stakingAddress: string
+): Promise<{ info: PythStakingInfo; stakingAddress: string }> {
   const [rewards, positions, targetAccount, poolData, rewardCustodyAccount] =
     await Promise.all([
-      getClaimableRewards(responsiveClient, stakeAccount).catch(() => ({
+      getClaimableRewards(client, stakeAccount).catch(() => ({
         totalRewards: 0n,
       })),
-      responsiveClient.getStakeAccountPositions(stakeAccount),
-      responsiveClient.getTargetAccount(),
-      responsiveClient.getPoolDataAccount(),
-      responsiveClient.getRewardCustodyAccount(),
+      client.getStakeAccountPositions(stakeAccount),
+      client.getTargetAccount(),
+      client.getPoolDataAccount(),
+      client.getRewardCustodyAccount(),
     ]);
 
   const generalStats: PythGeneralStats = {

--- a/action/pythActions.ts
+++ b/action/pythActions.ts
@@ -12,6 +12,7 @@ import {
 import { PublicKey, Connection } from "@solana/web3.js";
 
 const INITIAL_REWARD_POOL_SIZE = 60_000_000_000_000n;
+const STAKE_ACCOUNT_DISCOVERY_TIMEOUT_MS = 10000;
 
 // RPC endpoints with fallback support
 const RPC_ENDPOINTS = [
@@ -46,34 +47,26 @@ function isValidSolanaAddress(address: string): boolean {
 }
 
 /**
- * Retrieves staking information for a given wallet address and staking address.
+ * Retrieves staking information for a given wallet address.
+ * Automatically discovers the staking account from the wallet address.
  * @param {string} walletAddress - The public key of the wallet to use.
- * @param {string} stakingAddress - The public key of the staking account.
- * @returns {Promise<PythStakingInfo>} - A promise that resolves to an object containing staking information.
+ * @returns {Promise<{ info: PythStakingInfo; stakingAddress: string }>} - A promise that resolves to staking info and the discovered staking address.
  */
 export async function getOISStakingInfo(
-  walletAddress: string,
-  stakingAddress: string
-): Promise<PythStakingInfo> {
-  // Input validation
-  if (!walletAddress || !stakingAddress) {
-    throw new Error("Wallet address and staking address are required");
+  walletAddress: string
+): Promise<{ info: PythStakingInfo; stakingAddress: string }> {
+  if (!walletAddress) {
+    throw new Error("Wallet address is required");
   }
 
   if (!isValidSolanaAddress(walletAddress)) {
     throw new Error("Invalid wallet address format");
   }
 
-  if (!isValidSolanaAddress(stakingAddress)) {
-    throw new Error("Invalid staking address format");
-  }
-
-  let stakeAccount: PublicKey;
   let walletPublicKey: PublicKey;
   let client: PythStakingClient;
 
   try {
-    stakeAccount = new PublicKey(stakingAddress);
     walletPublicKey = new PublicKey(walletAddress);
   } catch (error) {
     const errorMessage =
@@ -89,50 +82,50 @@ export async function getOISStakingInfo(
     throw new Error(`Failed to create Pyth staking client: ${errorMessage}`);
   }
 
+  const { client: responsiveClient, stakeAccount } = await discoverStakeAccount(
+    client,
+    walletPublicKey
+  );
+
   try {
-    try {
-      const accountInfo = await client.connection.getAccountInfo(stakeAccount);
-      if (!accountInfo) {
-        throw new Error("Staking account does not exist");
-      }
-    } catch (accountError) {
-      throw new Error("Staking account does not exist or is invalid");
-    }
+    // Fetch everything in one parallel batch.
+    // poolData is fetched once and reused for both generalStats and publisherPoolData.
+    // getClaimableRewards runs in parallel with the rest; failures fall back to 0.
+    const [rewards, positions, targetAccount, poolData, rewardCustodyAccount] =
+      await Promise.all([
+        getClaimableRewards(responsiveClient, stakeAccount).catch(() => ({
+          totalRewards: 0n,
+        })),
+        responsiveClient.getStakeAccountPositions(stakeAccount),
+        responsiveClient.getTargetAccount(),
+        responsiveClient.getPoolDataAccount(),
+        responsiveClient.getRewardCustodyAccount(),
+      ]);
 
-    // Try to fetch rewards with fallback mechanism
-    let rewards;
-    let rewardsSuccess = false;
+    const generalStats: PythGeneralStats = {
+      totalGovernance:
+        Number(targetAccount.locked + targetAccount.deltaLocked) * 1e-6,
+      totalStaked:
+        Number(
+          sumDelegations(poolData.delState) +
+            sumDelegations(poolData.selfDelState)
+        ) * 1e-6,
+      rewardsDistributed:
+        Number(
+          poolData.claimableRewards +
+            INITIAL_REWARD_POOL_SIZE -
+            rewardCustodyAccount.amount
+        ) * 1e-6,
+    };
 
-    // Try with current client first
-    try {
-      rewards = await getClaimableRewards(client, stakeAccount);
-      rewardsSuccess = true;
-    } catch (rewardError) {
-      // Try with different RPC endpoints
-      for (let i = 1; i < RPC_ENDPOINTS.length && !rewardsSuccess; i++) {
-        try {
-          const fallbackClient = createPythStakingClientWithFallback(
-            walletPublicKey,
-            i
-          );
-          rewards = await getClaimableRewards(fallbackClient, stakeAccount);
-          rewardsSuccess = true;
-        } catch (fallbackError) {
-          // Continue to next endpoint
-        }
-      }
-
-      if (!rewardsSuccess) {
-        rewards = { totalRewards: 0n };
-      }
-    }
-
-    // Fetch other data in parallel
-    const [generalStats, positions, publisherPoolData] = await Promise.all([
-      getPythGeneralStats(client),
-      client.getStakeAccountPositions(stakeAccount),
-      getPublisherPoolData(client),
-    ]);
+    const publisherPoolData = extractPublisherData(poolData).map(
+      ({ totalDelegation, totalDelegationDelta, pubkey, apyHistory }) => ({
+        totalDelegation,
+        totalDelegationDelta,
+        pubkey: pubkey.toBase58(),
+        apy: apyHistory[apyHistory.length - 1]?.apy ?? 0,
+      })
+    );
 
     // Calculate claimable rewards in PYTH
     const claimableRewards = Number(rewards?.totalRewards || 0n) * 1e-6;
@@ -175,10 +168,13 @@ export async function getOISStakingInfo(
     });
 
     return {
-      StakeForEachPublisher,
-      totalStakedPyth,
-      claimableRewards,
-      generalStats,
+      info: {
+        StakeForEachPublisher,
+        totalStakedPyth,
+        claimableRewards,
+        generalStats,
+      },
+      stakingAddress: stakeAccount.toBase58(),
     };
   } catch (error) {
     console.error("Error retrieving staking information:", error);
@@ -262,6 +258,90 @@ function createPythStakingClientWithFallback(
       signAllTransactions: () => Promise.reject("Not implemented"),
       signTransaction: () => Promise.reject("Not implemented"),
     },
+  });
+}
+
+/**
+ * Discovers the stake account address for a wallet, with RPC fallback.
+ */
+async function discoverStakeAccount(
+  client: PythStakingClient,
+  walletPublicKey: PublicKey
+): Promise<{ client: PythStakingClient; stakeAccount: PublicKey }> {
+  const clients = RPC_ENDPOINTS.map((_, index) =>
+    index === 0
+      ? client
+      : createPythStakingClientWithFallback(walletPublicKey, index)
+  );
+
+  const failures: string[] = [];
+
+  try {
+    const discovery = Promise.any(
+      clients.map(async (rpcClient) => {
+        try {
+          const mainAccount = await rpcClient.getMainStakeAccount(walletPublicKey);
+
+          if (!mainAccount) {
+            throw new Error("No staking account found for this wallet");
+          }
+
+          return {
+            client: rpcClient,
+            stakeAccount: mainAccount.stakeAccountPosition,
+          };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : "Unknown error";
+          failures.push(msg);
+          throw error;
+        }
+      })
+    );
+
+    return await withTimeout(
+      discovery,
+      STAKE_ACCOUNT_DISCOVERY_TIMEOUT_MS,
+      "Stake account discovery timed out across all RPC endpoints"
+    );
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+
+    if (errorMessage.includes("timed out across all RPC endpoints")) {
+      throw new Error(
+        "Failed to discover staking account: all RPC endpoints timed out"
+      );
+    }
+
+    if (failures.some((msg) => msg.startsWith("No staking account"))) {
+      throw new Error("No staking account found for this wallet");
+    }
+
+    const lastError = failures[failures.length - 1] ?? "Unknown error";
+    throw new Error(`Failed to discover staking account: ${lastError}`);
+  }
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(timeoutMessage));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      }
+    );
   });
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,10 +4,9 @@ import { PortfolioSummary } from "@/components/portfolio-summary";
 import { MetricCards } from "@/components/metric-cards";
 import { GeneralSummary } from "@/components/general-summary";
 import { DashboardSkeleton } from "@/components/dashboard-skeleton";
-import { useAppLoading } from "@/components/app-layout";
+import { useAppLoading } from "@/components/app-loading-context";
 import { useWalletInfosStore } from "@/store/store";
 import { usePythPrice } from "@/hooks/use-pyth-price";
-import { Wallet } from "lucide-react";
 
 export default function Dashboard() {
   const { wallets } = useWalletInfosStore();

--- a/components/app-layout.tsx
+++ b/components/app-layout.tsx
@@ -4,8 +4,6 @@ import {
   useEffect,
   useState,
   useCallback,
-  createContext,
-  useContext,
 } from "react";
 import { Sidebar } from "@/components/sidebar";
 import { TopHeader } from "@/components/top-header";
@@ -13,13 +11,7 @@ import { useWalletInfosStore } from "@/store/store";
 import { refreshOISStakingInfo } from "@/action/pythActions";
 import { usePythPrice } from "@/hooks/use-pyth-price";
 import { refreshWalletsSequentially } from "@/lib/wallet-refresh";
-
-// Create loading context
-const LoadingContext = createContext<{
-  isLoading: boolean;
-}>({ isLoading: false });
-
-export const useAppLoading = () => useContext(LoadingContext);
+import { AppLoadingContext } from "@/components/app-loading-context";
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -28,6 +20,13 @@ interface AppLayoutProps {
 export function AppLayout({ children }: AppLayoutProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshingWallets, setIsRefreshingWallets] = useState(false);
+  const [lastWalletRefreshAt, setLastWalletRefreshAt] = useState<number | null>(
+    null
+  );
+  const [walletRefreshError, setWalletRefreshError] = useState<string | null>(
+    null
+  );
 
   const { wallets, setWallets } = useWalletInfosStore();
   const pythPrice = usePythPrice();
@@ -44,27 +43,44 @@ export function AppLayout({ children }: AppLayoutProps) {
     async function refreshWalletsInBackground(
       storedWallets: typeof wallets
     ): Promise<void> {
-      const refreshed = await refreshWalletsSequentially(
-        storedWallets,
-        async (wallet) => {
-          const next = await refreshOISStakingInfo(
-            wallet.address,
-            wallet.stakingAddress
-          );
-          return next;
-        },
-        (nextWallets) => {
-          if (isMounted) {
-            setWallets(nextWallets);
+      if (isMounted) {
+        setIsRefreshingWallets(true);
+        setWalletRefreshError(null);
+      }
+
+      try {
+        const result = await refreshWalletsSequentially(
+          storedWallets,
+          async (wallet) => {
+            const next = await refreshOISStakingInfo(
+              wallet.address,
+              wallet.stakingAddress
+            );
+            return next;
+          },
+          (nextWallets) => {
+            if (isMounted) {
+              setWallets(nextWallets);
+            }
+          }
+        );
+
+        if (isMounted) {
+          try {
+            localStorage.setItem("wallets", JSON.stringify(result.wallets));
+          } catch {
+            // localStorage might be unavailable
+          }
+
+          if (result.hadErrors) {
+            setWalletRefreshError(result.errorMessage);
+          } else {
+            setLastWalletRefreshAt(Date.now());
           }
         }
-      );
-
-      if (isMounted) {
-        try {
-          localStorage.setItem("wallets", JSON.stringify(refreshed));
-        } catch {
-          // localStorage might be unavailable
+      } finally {
+        if (isMounted) {
+          setIsRefreshingWallets(false);
         }
       }
     }
@@ -154,7 +170,14 @@ export function AppLayout({ children }: AppLayoutProps) {
   // Pyth price is now handled by usePythPrice hook
 
   return (
-    <LoadingContext.Provider value={{ isLoading }}>
+    <AppLoadingContext.Provider
+      value={{
+        isLoading,
+        isRefreshingWallets,
+        lastWalletRefreshAt,
+        walletRefreshError,
+      }}
+    >
       <div className="flex h-screen overflow-x-hidden bg-[#261e35]">
         <Sidebar
           isMobileMenuOpen={isMobileMenuOpen}
@@ -177,6 +200,6 @@ export function AppLayout({ children }: AppLayoutProps) {
           </main>
         </div>
       </div>
-    </LoadingContext.Provider>
+    </AppLoadingContext.Provider>
   );
 }

--- a/components/app-layout.tsx
+++ b/components/app-layout.tsx
@@ -10,8 +10,9 @@ import {
 import { Sidebar } from "@/components/sidebar";
 import { TopHeader } from "@/components/top-header";
 import { useWalletInfosStore } from "@/store/store";
-import { getOISStakingInfo } from "@/action/pythActions";
+import { refreshOISStakingInfo } from "@/action/pythActions";
 import { usePythPrice } from "@/hooks/use-pyth-price";
+import { refreshWalletsSequentially } from "@/lib/wallet-refresh";
 
 // Create loading context
 const LoadingContext = createContext<{
@@ -38,10 +39,35 @@ export function AppLayout({ children }: AppLayoutProps) {
   // Load wallets from localStorage - iOS/Mobile compatible version
   useEffect(() => {
     let isMounted = true;
-
-    // Set loading to false immediately on mount (don't block UI)
-    // We'll load wallets in the background
     setIsLoading(false);
+
+    async function refreshWalletsInBackground(
+      storedWallets: typeof wallets
+    ): Promise<void> {
+      const refreshed = await refreshWalletsSequentially(
+        storedWallets,
+        async (wallet) => {
+          const next = await refreshOISStakingInfo(
+            wallet.address,
+            wallet.stakingAddress
+          );
+          return next;
+        },
+        (nextWallets) => {
+          if (isMounted) {
+            setWallets(nextWallets);
+          }
+        }
+      );
+
+      if (isMounted) {
+        try {
+          localStorage.setItem("wallets", JSON.stringify(refreshed));
+        } catch {
+          // localStorage might be unavailable
+        }
+      }
+    }
 
     function loadWallets() {
       // Check if we're in a browser environment
@@ -78,6 +104,12 @@ export function AppLayout({ children }: AppLayoutProps) {
           setWallets(wallets);
         }
 
+        if (wallets.length > 0) {
+          setTimeout(() => {
+            void refreshWalletsInBackground(wallets);
+          }, 0);
+        }
+
         // Try to initialize localStorage if empty (but don't fail if it's disabled)
         if (!storedWallets) {
           try {
@@ -95,13 +127,7 @@ export function AppLayout({ children }: AppLayoutProps) {
       }
     }
 
-    // Load wallets asynchronously (don't block UI)
-    // Use requestIdleCallback if available, otherwise setTimeout
-    if (typeof window !== "undefined" && "requestIdleCallback" in window) {
-      (window as any).requestIdleCallback(loadWallets, { timeout: 100 });
-    } else {
-      setTimeout(loadWallets, 0);
-    }
+    loadWallets();
 
     return () => {
       isMounted = false;

--- a/components/app-loading-context.ts
+++ b/components/app-loading-context.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+export type AppLoadingState = {
+  isLoading: boolean;
+  isRefreshingWallets: boolean;
+  lastWalletRefreshAt: number | null;
+  walletRefreshError: string | null;
+};
+
+export const AppLoadingContext = createContext<AppLoadingState>({
+  isLoading: false,
+  isRefreshingWallets: false,
+  lastWalletRefreshAt: null,
+  walletRefreshError: null,
+});
+
+export const useAppLoading = () => useContext(AppLoadingContext);

--- a/components/top-header.tsx
+++ b/components/top-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ChevronDown, Download, Github, Menu, X } from "lucide-react";
 import { usePathname } from "next/navigation";
@@ -22,11 +22,14 @@ export function TopHeader({
   onMobileMenuToggle,
 }: TopHeaderProps) {
   const [showWalletDropdown, setShowWalletDropdown] = useState(false);
+  const [showRefreshComplete, setShowRefreshComplete] = useState(false);
+  const [isRefreshCompleteFading, setIsRefreshCompleteFading] = useState(false);
   const { canInstall, installApp } = usePwaInstall();
   const { isRefreshingWallets, lastWalletRefreshAt, walletRefreshError } =
     useAppLoading();
   const pathname = usePathname();
   const walletMenuRef = useRef<HTMLDivElement>(null);
+  const wasRefreshingRef = useRef(false);
 
   const pageTitle =
     pathname === "/"
@@ -39,6 +42,45 @@ export function TopHeader({
             ? "Reserve"
             : "Pyth Dashboard";
 
+  useEffect(() => {
+    let fadeTimer: ReturnType<typeof setTimeout> | undefined;
+    let hideTimer: ReturnType<typeof setTimeout> | undefined;
+
+    if (isRefreshingWallets) {
+      wasRefreshingRef.current = true;
+      setShowRefreshComplete(false);
+      setIsRefreshCompleteFading(false);
+      return;
+    }
+
+    if (walletRefreshError) {
+      setShowRefreshComplete(false);
+      setIsRefreshCompleteFading(false);
+      wasRefreshingRef.current = false;
+      return;
+    }
+
+    if (wasRefreshingRef.current && lastWalletRefreshAt) {
+      setShowRefreshComplete(true);
+      setIsRefreshCompleteFading(false);
+      wasRefreshingRef.current = false;
+
+      fadeTimer = setTimeout(() => {
+        setIsRefreshCompleteFading(true);
+      }, 1200);
+
+      hideTimer = setTimeout(() => {
+        setShowRefreshComplete(false);
+        setIsRefreshCompleteFading(false);
+      }, 1800);
+    }
+
+    return () => {
+      if (fadeTimer) clearTimeout(fadeTimer);
+      if (hideTimer) clearTimeout(hideTimer);
+    };
+  }, [isRefreshingWallets, lastWalletRefreshAt, walletRefreshError]);
+
   const walletRefreshStatus =
     walletRefreshError
       ? {
@@ -50,16 +92,17 @@ export function TopHeader({
         ? {
             label: "Refreshing wallet balances and rewards...",
             className:
-              "border-cyan-400/20 bg-cyan-300/10 text-cyan-50",
+              "border-cyan-400/30 bg-cyan-300/12 text-cyan-50 shadow-[0_0_24px_rgba(34,211,238,0.25)] animate-pulse",
           }
-        : lastWalletRefreshAt
+        : showRefreshComplete
           ? {
-              label: `Wallets updated ${new Intl.DateTimeFormat(undefined, {
-                hour: "2-digit",
-                minute: "2-digit",
-              }).format(lastWalletRefreshAt)}`,
+              label: "Wallet balances refreshed",
               className:
-                "border-emerald-400/20 bg-emerald-300/10 text-emerald-50",
+                `border-emerald-400/20 bg-emerald-300/10 text-emerald-50 transition-all duration-500 ${
+                  isRefreshCompleteFading
+                    ? "translate-y-[-4px] opacity-0"
+                    : "translate-y-0 opacity-100"
+                }`,
             }
           : null;
 
@@ -86,14 +129,6 @@ export function TopHeader({
           <span className="hidden rounded-xl border border-white/8 bg-[#2f2942] px-2.5 py-1 text-[11px] font-semibold tracking-[0.12em] text-[#b8b0d0] sm:inline-flex">
             {packageJson.version}
           </span>
-          {walletRefreshStatus ? (
-            <div
-              className={`hidden max-w-[28rem] truncate rounded-full border px-3 py-1 text-[11px] font-medium xl:inline-flex ${walletRefreshStatus.className}`}
-              title={walletRefreshStatus.label}
-            >
-              {walletRefreshStatus.label}
-            </div>
-          ) : null}
           <div className="hidden min-w-0 items-center gap-1.5 sm:flex lg:gap-2">
             {canInstall ? (
               <Button
@@ -148,6 +183,14 @@ export function TopHeader({
                 <span className="hidden 2xl:inline">Built by SCPTech</span>
               </Link>
             </Button>
+            {walletRefreshStatus ? (
+              <div
+                className={`hidden max-w-[24rem] truncate rounded-full border px-3 py-1 text-[11px] font-medium 2xl:inline-flex ${walletRefreshStatus.className}`}
+                title={walletRefreshStatus.label}
+              >
+                {walletRefreshStatus.label}
+              </div>
+            ) : null}
           </div>
         </div>
       </div>

--- a/components/top-header.tsx
+++ b/components/top-header.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { WalletDropdown } from "@/components/wallet-dropdown";
 import { PriceTicker } from "@/components/price-ticker";
 import { usePwaInstall } from "@/components/pwa-install-context";
+import { useAppLoading } from "@/components/app-loading-context";
 import packageJson from "@/package.json";
 
 interface TopHeaderProps {
@@ -22,6 +23,8 @@ export function TopHeader({
 }: TopHeaderProps) {
   const [showWalletDropdown, setShowWalletDropdown] = useState(false);
   const { canInstall, installApp } = usePwaInstall();
+  const { isRefreshingWallets, lastWalletRefreshAt, walletRefreshError } =
+    useAppLoading();
   const pathname = usePathname();
   const walletMenuRef = useRef<HTMLDivElement>(null);
 
@@ -35,6 +38,30 @@ export function TopHeader({
           : pathname.startsWith("/reserve")
             ? "Reserve"
             : "Pyth Dashboard";
+
+  const walletRefreshStatus =
+    walletRefreshError
+      ? {
+          label: walletRefreshError,
+          className:
+            "border-amber-400/20 bg-amber-300/10 text-amber-100",
+        }
+      : isRefreshingWallets
+        ? {
+            label: "Refreshing wallet balances and rewards...",
+            className:
+              "border-cyan-400/20 bg-cyan-300/10 text-cyan-50",
+          }
+        : lastWalletRefreshAt
+          ? {
+              label: `Wallets updated ${new Intl.DateTimeFormat(undefined, {
+                hour: "2-digit",
+                minute: "2-digit",
+              }).format(lastWalletRefreshAt)}`,
+              className:
+                "border-emerald-400/20 bg-emerald-300/10 text-emerald-50",
+            }
+          : null;
 
   return (
     <header className="flex min-h-20 items-center justify-between gap-3 border-b border-white/6 bg-[#241b35] px-3 py-3 sm:px-6">
@@ -59,6 +86,14 @@ export function TopHeader({
           <span className="hidden rounded-xl border border-white/8 bg-[#2f2942] px-2.5 py-1 text-[11px] font-semibold tracking-[0.12em] text-[#b8b0d0] sm:inline-flex">
             {packageJson.version}
           </span>
+          {walletRefreshStatus ? (
+            <div
+              className={`hidden max-w-[28rem] truncate rounded-full border px-3 py-1 text-[11px] font-medium xl:inline-flex ${walletRefreshStatus.className}`}
+              title={walletRefreshStatus.label}
+            >
+              {walletRefreshStatus.label}
+            </div>
+          ) : null}
           <div className="hidden min-w-0 items-center gap-1.5 sm:flex lg:gap-2">
             {canInstall ? (
               <Button

--- a/components/wallet-dropdown.tsx
+++ b/components/wallet-dropdown.tsx
@@ -120,19 +120,20 @@ export function WalletDropdown({
       });
     } catch (error) {
       console.error("Error fetching Pyth staking info:", error);
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Failed to add wallet. Please try again later.";
 
       // Error toast with different styling
-      toast.error(
-        "Failed to add wallet. Please check the addresses and try again.",
-        {
-          duration: 5000,
-          style: {
-            background: "#7f1d1d",
-            color: "#f1f5f9",
-            border: "1px solid #991b1b",
-          },
-        }
-      );
+      toast.error(errorMessage, {
+        duration: 5000,
+        style: {
+          background: "#7f1d1d",
+          color: "#f1f5f9",
+          border: "1px solid #991b1b",
+        },
+      });
     } finally {
       setIsLoading(false);
       setShowAddForm(false);

--- a/components/wallet-dropdown.tsx
+++ b/components/wallet-dropdown.tsx
@@ -8,10 +8,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Loader, Plus, Trash2, X } from "lucide-react";
-import { PythStakingInfo } from "@/types/pythTypes";
 import { useWalletInfosStore } from "@/store/store";
 import { getOISStakingInfo } from "@/action/pythActions";
-import { StakingHelpPopup } from "@/components/staking-help-popup";
 import toast from "react-hot-toast";
 
 interface WalletDropdownProps {
@@ -62,12 +60,8 @@ export function WalletDropdown({
     const formData = new FormData(e.currentTarget);
     const name = formData.get("wallet-name") as string;
     const address = formData.get("wallet-address") as string;
-    const stakingAddress = formData.get("staking-address") as string;
 
-    if (
-      wallets.some((wallet) => wallet.address === address) ||
-      wallets.some((wallet) => wallet.stakingAddress === stakingAddress)
-    ) {
+    if (wallets.some((wallet) => wallet.address === address)) {
       onClose();
       toast.error("This wallet address is already added.", {
         duration: 4000,
@@ -79,20 +73,14 @@ export function WalletDropdown({
       });
       return;
     }
-    fetchPythStakingInfo(address, stakingAddress, name);
+    fetchPythStakingInfo(address, name);
   }
 
-  async function fetchPythStakingInfo(
-    walletAddress: string,
-    stakingAddress: string,
-    name: string
-  ) {
+  async function fetchPythStakingInfo(walletAddress: string, name: string) {
     setIsLoading(true);
     try {
-      const pythStakingInfo: PythStakingInfo = await getOISStakingInfo(
-        walletAddress,
-        stakingAddress
-      );
+      const { info: pythStakingInfo, stakingAddress } =
+        await getOISStakingInfo(walletAddress);
 
       if (!pythStakingInfo) {
         throw new Error("Failed to fetch Pyth staking info");
@@ -103,7 +91,7 @@ export function WalletDropdown({
         id: walletAddress,
         name: name,
         address: walletAddress,
-        stakingAddress: stakingAddress,
+        stakingAddress,
         stakingInfo: pythStakingInfo,
       });
 
@@ -115,7 +103,7 @@ export function WalletDropdown({
             id: walletAddress,
             name: name,
             address: walletAddress,
-            stakingAddress: stakingAddress,
+            stakingAddress,
             stakingInfo: pythStakingInfo,
           },
         ])
@@ -285,25 +273,6 @@ export function WalletDropdown({
                   name="wallet-address"
                   type="text"
                   placeholder="Enter Solana wallet address"
-                  className="rounded-2xl border-white/8 bg-[#241d34] text-white font-mono text-xs sm:text-sm"
-                  required
-                />
-              </div>
-              <div className="space-y-2 sm:space-y-4">
-                <div className="flex items-center gap-2 mb-1 sm:mb-2">
-                  <Label
-                    htmlFor="staking-address"
-                    className="text-[#d8d3ea] text-sm"
-                  >
-                    Staking Account Address
-                  </Label>
-                  <StakingHelpPopup />
-                </div>
-                <Input
-                  id="staking-address"
-                  name="staking-address"
-                  type="text"
-                  placeholder="Enter your pyth staking address"
                   className="rounded-2xl border-white/8 bg-[#241d34] text-white font-mono text-xs sm:text-sm"
                   required
                 />

--- a/lib/wallet-refresh.ts
+++ b/lib/wallet-refresh.ts
@@ -9,8 +9,13 @@ export async function refreshWalletsSequentially(
   wallets: WalletInfo[],
   refreshWallet: (wallet: WalletInfo) => Promise<RefreshWalletResult>,
   onUpdate: (wallets: WalletInfo[]) => void
-): Promise<WalletInfo[]> {
+): Promise<{
+  wallets: WalletInfo[];
+  hadErrors: boolean;
+  errorMessage: string | null;
+}> {
   const refreshed = [...wallets];
+  let hadErrors = false;
 
   for (let index = 0; index < refreshed.length; index++) {
     const wallet = refreshed[index];
@@ -23,11 +28,18 @@ export async function refreshWalletsSequentially(
         stakingInfo: next.info,
       };
     } catch {
+      hadErrors = true;
       refreshed[index] = wallet;
     }
 
     onUpdate([...refreshed]);
   }
 
-  return refreshed;
+  return {
+    wallets: refreshed,
+    hadErrors,
+    errorMessage: hadErrors
+      ? "Some wallet balances could not be refreshed. Try again later."
+      : null,
+  };
 }

--- a/lib/wallet-refresh.ts
+++ b/lib/wallet-refresh.ts
@@ -1,0 +1,33 @@
+import type { WalletInfo } from "@/types/pythTypes";
+
+type RefreshWalletResult = {
+  info: WalletInfo["stakingInfo"];
+  stakingAddress: string;
+};
+
+export async function refreshWalletsSequentially(
+  wallets: WalletInfo[],
+  refreshWallet: (wallet: WalletInfo) => Promise<RefreshWalletResult>,
+  onUpdate: (wallets: WalletInfo[]) => void
+): Promise<WalletInfo[]> {
+  const refreshed = [...wallets];
+
+  for (let index = 0; index < refreshed.length; index++) {
+    const wallet = refreshed[index];
+
+    try {
+      const next = await refreshWallet(wallet);
+      refreshed[index] = {
+        ...wallet,
+        stakingAddress: next.stakingAddress,
+        stakingInfo: next.info,
+      };
+    } catch {
+      refreshed[index] = wallet;
+    }
+
+    onUpdate([...refreshed]);
+  }
+
+  return refreshed;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pyth-board",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pyth-board",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@pythnetwork/staking-sdk": "^0.3.0",
         "@radix-ui/react-dialog": "^1.1.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pyth-board",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/tests/priceActions.test.ts
+++ b/tests/priceActions.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Mock global fetch ────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function hermesLatestResponse(price: number) {
+  return {
+    ok: true,
+    json: async () => ({
+      parsed: [{ price: { price: String(Math.round(price * 1e8)), expo: -8 } }],
+    }),
+  };
+}
+
+function hermesHistoricalResponse(price: number) {
+  return hermesLatestResponse(price);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+import { getRealtimePrices } from "@/action/priceActions";
+
+describe("getRealtimePrices", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("never calls CoinGecko", async () => {
+    // Return valid Hermes responses for all 4 calls (2 latest + 2 historical)
+    mockFetch.mockResolvedValue(hermesLatestResponse(150));
+
+    await getRealtimePrices();
+
+    const urls: string[] = mockFetch.mock.calls.map((c) => c[0] as string);
+    expect(urls.every((u) => !u.includes("coingecko"))).toBe(true);
+  });
+
+  it("fetches both latest and 24h-ago prices from Hermes for each asset", async () => {
+    mockFetch.mockResolvedValue(hermesLatestResponse(150));
+
+    await getRealtimePrices();
+
+    const urls: string[] = mockFetch.mock.calls.map((c) => c[0] as string);
+    const latestCalls = urls.filter((u) => u.includes("/price/latest"));
+    const historicalCalls = urls.filter((u) => !u.includes("/price/latest"));
+
+    expect(latestCalls.length).toBeGreaterThanOrEqual(2); // SOL + PYTH latest
+    expect(historicalCalls.length).toBeGreaterThanOrEqual(2); // SOL + PYTH 24h ago
+  });
+
+  it("computes positive 24h change correctly", async () => {
+    // SOL: was $100, now $110 → +10%
+    // PYTH: was $0.50, now $0.50 → 0%
+    let callCount = 0;
+    mockFetch.mockImplementation((url: string) => {
+      callCount++;
+      // latest calls come first in Promise.all, then historical
+      // We'll key off call order: 1=SOL latest, 2=PYTH latest, 3=SOL 24h, 4=PYTH 24h
+      if (url.includes("/price/latest")) {
+        return Promise.resolve(
+          url.includes("ef0d8b6f")
+            ? hermesLatestResponse(110) // SOL now
+            : hermesLatestResponse(0.5) // PYTH now
+        );
+      } else {
+        return Promise.resolve(
+          url.includes("ef0d8b6f")
+            ? hermesHistoricalResponse(100) // SOL 24h ago
+            : hermesHistoricalResponse(0.5) // PYTH 24h ago
+        );
+      }
+    });
+
+    const result = await getRealtimePrices();
+
+    expect(result.sol.change24h).toBeCloseTo(10, 0); // ~10%
+    expect(result.pyth.change24h).toBeCloseTo(0, 1);
+  });
+
+  it("computes negative 24h change correctly", async () => {
+    // SOL: was $200, now $150 → -25%
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/price/latest")) {
+        return Promise.resolve(
+          url.includes("ef0d8b6f")
+            ? hermesLatestResponse(150)
+            : hermesLatestResponse(0.5)
+        );
+      } else {
+        return Promise.resolve(
+          url.includes("ef0d8b6f")
+            ? hermesHistoricalResponse(200)
+            : hermesHistoricalResponse(0.5)
+        );
+      }
+    });
+
+    const result = await getRealtimePrices();
+
+    expect(result.sol.change24h).toBeCloseTo(-25, 0);
+  });
+
+  it("returns zero change when historical price is unavailable", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/price/latest")) {
+        return Promise.resolve(hermesLatestResponse(150));
+      }
+      // historical fetch fails
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    });
+
+    const result = await getRealtimePrices();
+
+    expect(result.sol.change24h).toBe(0);
+    expect(result.sol.price).toBeCloseTo(150);
+  });
+
+  it("returns the correct price shape", async () => {
+    mockFetch.mockResolvedValue(hermesLatestResponse(150));
+
+    const result = await getRealtimePrices();
+
+    expect(result.sol).toMatchObject({
+      symbol: "SOL",
+      price: expect.any(Number),
+      change24h: expect.any(Number),
+      change24hValue: expect.any(Number),
+    });
+    expect(result.pyth).toMatchObject({
+      symbol: "PYTH",
+      price: expect.any(Number),
+      change24h: expect.any(Number),
+      change24hValue: expect.any(Number),
+    });
+  });
+});

--- a/tests/pythActions.test.ts
+++ b/tests/pythActions.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+
+// ─── Hoisted mocks (available inside vi.mock factories) ──────────────────────
+
+const {
+  mockClient,
+  mockClients,
+  mockExtractPublisherData,
+  MockPythStakingClient,
+} =
+  vi.hoisted(() => {
+    const createMockClient = () => ({
+      getMainStakeAccount: vi.fn(),
+      getClaimableRewards: vi.fn(),
+      getStakeAccountPositions: vi.fn(),
+      getTargetAccount: vi.fn(),
+      getPoolDataAccount: vi.fn(),
+      getRewardCustodyAccount: vi.fn(),
+      wallet: { publicKey: null as unknown as PublicKey },
+      connection: {},
+    });
+
+    const mockClient = createMockClient();
+    const mockClients: ReturnType<typeof createMockClient>[] = [];
+
+    // Regular function so `new PythStakingClient(...)` works in production code
+    function MockPythStakingClient(this: unknown) {
+      return mockClients.shift() ?? mockClient;
+    }
+
+    return {
+      mockClient,
+      mockClients,
+      mockExtractPublisherData: vi.fn(),
+      MockPythStakingClient,
+    };
+  });
+
+vi.mock("@pythnetwork/staking-sdk", () => ({
+  PythStakingClient: MockPythStakingClient,
+  extractPublisherData: mockExtractPublisherData,
+}));
+
+// Keep real PublicKey for address validation; only stub Connection
+vi.mock("@solana/web3.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solana/web3.js")>();
+  return { ...actual, Connection: class MockConnection {} };
+});
+
+// ─── Test fixtures ────────────────────────────────────────────────────────────
+
+const WALLET_ADDRESS = "11111111111111111111111111111111"; // system program — valid 32-byte key
+const STAKING_ADDRESS = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+
+function makePoolData() {
+  return {
+    delState: [{ totalDelegation: 500_000_000n, deltaDelegation: 0n }],
+    selfDelState: [{ totalDelegation: 100_000_000n, deltaDelegation: 0n }],
+    claimableRewards: 5_000_000n,
+    publishers: [],
+  };
+}
+
+function setupHappyPath() {
+  const stakingPubkey = new PublicKey(STAKING_ADDRESS);
+
+  mockClient.getMainStakeAccount.mockResolvedValue({
+    stakeAccountPosition: stakingPubkey,
+  });
+
+  mockClient.getClaimableRewards.mockResolvedValue({ totalRewards: 1_000_000n }); // 1 PYTH
+
+  mockClient.getStakeAccountPositions.mockResolvedValue({
+    address: stakingPubkey,
+    data: {
+      owner: new PublicKey(WALLET_ADDRESS),
+      positions: [
+        {
+          amount: 500_000_000n, // 500 PYTH
+          targetWithParameters: {
+            integrityPool: { publisher: new PublicKey(WALLET_ADDRESS) },
+          },
+        },
+      ],
+    },
+  });
+
+  const poolData = makePoolData();
+  mockClient.getPoolDataAccount.mockResolvedValue(poolData);
+  mockClient.getTargetAccount.mockResolvedValue({
+    locked: 10_000_000_000n,
+    deltaLocked: 0n,
+  });
+  mockClient.getRewardCustodyAccount.mockResolvedValue({
+    amount: 55_000_000n,
+  });
+
+  mockExtractPublisherData.mockReturnValue([
+    {
+      totalDelegation: 500_000_000n,
+      totalDelegationDelta: 0n,
+      pubkey: new PublicKey(WALLET_ADDRESS),
+      apyHistory: [{ apy: 0.08 }],
+    },
+  ]);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+import { getOISStakingInfo } from "@/action/pythActions";
+
+describe("getOISStakingInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClients.length = 0;
+  });
+
+  // ── Input validation ────────────────────────────────────────────────────────
+
+  it("throws if wallet address is empty", async () => {
+    await expect(getOISStakingInfo("")).rejects.toThrow(
+      "Wallet address is required"
+    );
+  });
+
+  it("throws if wallet address format is invalid", async () => {
+    await expect(getOISStakingInfo("not-a-valid-solana-address")).rejects.toThrow(
+      "Invalid wallet address format"
+    );
+  });
+
+  // ── Account discovery ───────────────────────────────────────────────────────
+
+  it("throws a clear error when no staking account exists for the wallet", async () => {
+    mockClient.getMainStakeAccount.mockResolvedValue(undefined);
+
+    await expect(getOISStakingInfo(WALLET_ADDRESS)).rejects.toThrow(
+      "No staking account found for this wallet"
+    );
+  });
+
+  it("calls getMainStakeAccount with the wallet public key to discover the staking account", async () => {
+    setupHappyPath();
+
+    await getOISStakingInfo(WALLET_ADDRESS);
+
+    expect(mockClient.getMainStakeAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ toBase58: expect.any(Function) })
+    );
+    const calledWith: PublicKey = mockClient.getMainStakeAccount.mock.calls[0][0];
+    expect(calledWith.toBase58()).toBe(WALLET_ADDRESS);
+  });
+
+  it("queries each RPC endpoint at most once during stake account discovery", async () => {
+    const stakingPubkey = new PublicKey(STAKING_ADDRESS);
+    const clients = Array.from({ length: 4 }, () => ({
+      getMainStakeAccount: vi.fn().mockResolvedValue({
+        stakeAccountPosition: stakingPubkey,
+      }),
+      getClaimableRewards: vi.fn().mockResolvedValue({ totalRewards: 1_000_000n }),
+      getStakeAccountPositions: vi.fn().mockResolvedValue({
+        address: stakingPubkey,
+        data: {
+          owner: new PublicKey(WALLET_ADDRESS),
+          positions: [],
+        },
+      }),
+      getTargetAccount: vi.fn().mockResolvedValue({
+        locked: 10_000_000_000n,
+        deltaLocked: 0n,
+      }),
+      getPoolDataAccount: vi.fn().mockResolvedValue(makePoolData()),
+      getRewardCustodyAccount: vi.fn().mockResolvedValue({
+        amount: 55_000_000n,
+      }),
+      wallet: { publicKey: null as unknown as PublicKey },
+      connection: {},
+    }));
+
+    mockExtractPublisherData.mockReturnValue([]);
+    mockClients.push(...clients);
+
+    await getOISStakingInfo(WALLET_ADDRESS);
+
+    clients.forEach((client) => {
+      expect(client.getMainStakeAccount).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("falls back quickly to a responsive RPC when an earlier endpoint hangs", async () => {
+    const stakingPubkey = new PublicKey(STAKING_ADDRESS);
+    const slowClient = {
+      getMainStakeAccount: vi.fn(
+        () => new Promise(() => undefined) as Promise<never>
+      ),
+      getClaimableRewards: vi.fn(),
+      getStakeAccountPositions: vi.fn(),
+      getTargetAccount: vi.fn(),
+      getPoolDataAccount: vi.fn(),
+      getRewardCustodyAccount: vi.fn(),
+      wallet: { publicKey: null as unknown as PublicKey },
+      connection: {},
+    };
+
+    const fastClient = {
+      getMainStakeAccount: vi.fn().mockResolvedValue({
+        stakeAccountPosition: stakingPubkey,
+      }),
+      getClaimableRewards: vi.fn().mockResolvedValue({ totalRewards: 1_000_000n }),
+      getStakeAccountPositions: vi.fn().mockResolvedValue({
+        address: stakingPubkey,
+        data: {
+          owner: new PublicKey(WALLET_ADDRESS),
+          positions: [],
+        },
+      }),
+      getTargetAccount: vi.fn().mockResolvedValue({
+        locked: 10_000_000_000n,
+        deltaLocked: 0n,
+      }),
+      getPoolDataAccount: vi.fn().mockResolvedValue(makePoolData()),
+      getRewardCustodyAccount: vi.fn().mockResolvedValue({
+        amount: 55_000_000n,
+      }),
+      wallet: { publicKey: null as unknown as PublicKey },
+      connection: {},
+    };
+
+    mockExtractPublisherData.mockReturnValue([]);
+    mockClients.push(slowClient, fastClient);
+
+    const result = await getOISStakingInfo(WALLET_ADDRESS);
+
+    expect(result.stakingAddress).toBe(STAKING_ADDRESS);
+    expect(fastClient.getMainStakeAccount).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Return shape ────────────────────────────────────────────────────────────
+
+  it("returns the auto-discovered staking address as a base58 string", async () => {
+    setupHappyPath();
+
+    const result = await getOISStakingInfo(WALLET_ADDRESS);
+
+    expect(result.stakingAddress).toBe(STAKING_ADDRESS);
+  });
+
+  it("returns staking info with expected shape", async () => {
+    setupHappyPath();
+
+    const result = await getOISStakingInfo(WALLET_ADDRESS);
+
+    expect(result.info).toMatchObject({
+      totalStakedPyth: expect.any(Number),
+      claimableRewards: expect.any(Number),
+      StakeForEachPublisher: expect.any(Array),
+      generalStats: expect.objectContaining({
+        totalGovernance: expect.any(Number),
+        totalStaked: expect.any(Number),
+        rewardsDistributed: expect.any(Number),
+      }),
+    });
+  });
+
+  it("returns correct totalStakedPyth from positions", async () => {
+    setupHappyPath();
+
+    const result = await getOISStakingInfo(WALLET_ADDRESS);
+
+    // 500_000_000 raw * 1e-6 = 500 PYTH
+    expect(result.info.totalStakedPyth).toBeCloseTo(500);
+  });
+
+  it("returns correct claimableRewards from SDK", async () => {
+    setupHappyPath();
+
+    const result = await getOISStakingInfo(WALLET_ADDRESS);
+
+    // 1_000_000 raw * 1e-6 = 1 PYTH
+    expect(result.info.claimableRewards).toBeCloseTo(1);
+  });
+});

--- a/tests/pythActions.test.ts
+++ b/tests/pythActions.test.ts
@@ -324,6 +324,55 @@ describe("refreshOISStakingInfo", () => {
     expect(mockClient.getMainStakeAccount).not.toHaveBeenCalled();
   });
 
+  it("uses the primary refresh client when it is healthy without probing fallback RPCs", async () => {
+    const stakingPubkey = new PublicKey(STAKING_ADDRESS);
+    const primaryClient = {
+      getMainStakeAccount: vi.fn(),
+      getClaimableRewards: vi.fn().mockResolvedValue({ totalRewards: 1_000_000n }),
+      getStakeAccountPositions: vi.fn().mockResolvedValue({
+        address: stakingPubkey,
+        data: {
+          owner: new PublicKey(WALLET_ADDRESS),
+          positions: [],
+        },
+      }),
+      getTargetAccount: vi.fn().mockResolvedValue({
+        locked: 10_000_000_000n,
+        deltaLocked: 0n,
+      }),
+      getPoolDataAccount: vi.fn().mockResolvedValue(makePoolData()),
+      getRewardCustodyAccount: vi.fn().mockResolvedValue({
+        amount: 55_000_000n,
+      }),
+      wallet: { publicKey: null as unknown as PublicKey },
+      connection: {},
+    };
+
+    const fallbackClient = {
+      getMainStakeAccount: vi.fn(),
+      getClaimableRewards: vi.fn(),
+      getStakeAccountPositions: vi.fn(),
+      getTargetAccount: vi.fn(),
+      getPoolDataAccount: vi.fn(),
+      getRewardCustodyAccount: vi.fn(),
+      wallet: { publicKey: null as unknown as PublicKey },
+      connection: {},
+    };
+
+    mockExtractPublisherData.mockReturnValue([]);
+    mockClients.push(primaryClient, fallbackClient);
+
+    const result = await refreshOISStakingInfo(
+      WALLET_ADDRESS,
+      STAKING_ADDRESS
+    );
+
+    expect(result.stakingAddress).toBe(STAKING_ADDRESS);
+    expect(primaryClient.getTargetAccount).toHaveBeenCalledTimes(1);
+    expect(fallbackClient.getTargetAccount).not.toHaveBeenCalled();
+    expect(fallbackClient.getStakeAccountPositions).not.toHaveBeenCalled();
+  });
+
   // ── Return shape ────────────────────────────────────────────────────────────
 
   it("returns the provided staking address unchanged", async () => {

--- a/tests/pythActions.test.ts
+++ b/tests/pythActions.test.ts
@@ -108,7 +108,7 @@ function setupHappyPath() {
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
-import { getOISStakingInfo } from "@/action/pythActions";
+import { getOISStakingInfo, refreshOISStakingInfo } from "@/action/pythActions";
 
 describe("getOISStakingInfo", () => {
   beforeEach(() => {
@@ -278,6 +278,92 @@ describe("getOISStakingInfo", () => {
     const result = await getOISStakingInfo(WALLET_ADDRESS);
 
     // 1_000_000 raw * 1e-6 = 1 PYTH
+    expect(result.info.claimableRewards).toBeCloseTo(1);
+  });
+});
+
+describe("refreshOISStakingInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClients.length = 0;
+  });
+
+  // ── Input validation ────────────────────────────────────────────────────────
+
+  it("throws if wallet address is empty", async () => {
+    await expect(refreshOISStakingInfo("", STAKING_ADDRESS)).rejects.toThrow(
+      "Wallet address is required"
+    );
+  });
+
+  it("throws if staking address is empty", async () => {
+    await expect(refreshOISStakingInfo(WALLET_ADDRESS, "")).rejects.toThrow(
+      "Staking address is required"
+    );
+  });
+
+  it("throws if wallet address format is invalid", async () => {
+    await expect(
+      refreshOISStakingInfo("not-a-valid-address", STAKING_ADDRESS)
+    ).rejects.toThrow("Invalid wallet address format");
+  });
+
+  it("throws if staking address format is invalid", async () => {
+    await expect(
+      refreshOISStakingInfo(WALLET_ADDRESS, "not-a-valid-address")
+    ).rejects.toThrow("Invalid staking address format");
+  });
+
+  // ── No discovery ────────────────────────────────────────────────────────────
+
+  it("does not call getMainStakeAccount — uses the known staking address directly", async () => {
+    setupHappyPath();
+
+    await refreshOISStakingInfo(WALLET_ADDRESS, STAKING_ADDRESS);
+
+    expect(mockClient.getMainStakeAccount).not.toHaveBeenCalled();
+  });
+
+  // ── Return shape ────────────────────────────────────────────────────────────
+
+  it("returns the provided staking address unchanged", async () => {
+    setupHappyPath();
+
+    const result = await refreshOISStakingInfo(WALLET_ADDRESS, STAKING_ADDRESS);
+
+    expect(result.stakingAddress).toBe(STAKING_ADDRESS);
+  });
+
+  it("returns staking info with expected shape", async () => {
+    setupHappyPath();
+
+    const result = await refreshOISStakingInfo(WALLET_ADDRESS, STAKING_ADDRESS);
+
+    expect(result.info).toMatchObject({
+      totalStakedPyth: expect.any(Number),
+      claimableRewards: expect.any(Number),
+      StakeForEachPublisher: expect.any(Array),
+      generalStats: expect.objectContaining({
+        totalGovernance: expect.any(Number),
+        totalStaked: expect.any(Number),
+        rewardsDistributed: expect.any(Number),
+      }),
+    });
+  });
+
+  it("returns correct totalStakedPyth from positions", async () => {
+    setupHappyPath();
+
+    const result = await refreshOISStakingInfo(WALLET_ADDRESS, STAKING_ADDRESS);
+
+    expect(result.info.totalStakedPyth).toBeCloseTo(500);
+  });
+
+  it("returns correct claimableRewards", async () => {
+    setupHappyPath();
+
+    const result = await refreshOISStakingInfo(WALLET_ADDRESS, STAKING_ADDRESS);
+
     expect(result.info.claimableRewards).toBeCloseTo(1);
   });
 });

--- a/tests/pythActions.test.ts
+++ b/tests/pythActions.test.ts
@@ -236,6 +236,34 @@ describe("getOISStakingInfo", () => {
     expect(fastClient.getMainStakeAccount).toHaveBeenCalledTimes(1);
   });
 
+  it("returns a clean user-facing error when stake account discovery times out", async () => {
+    const timeoutClient = {
+      getMainStakeAccount: vi
+        .fn()
+        .mockRejectedValue(
+          new Error("Stake account discovery timed out across all RPC endpoints")
+        ),
+      getClaimableRewards: vi.fn(),
+      getStakeAccountPositions: vi.fn(),
+      getTargetAccount: vi.fn(),
+      getPoolDataAccount: vi.fn(),
+      getRewardCustodyAccount: vi.fn(),
+      wallet: { publicKey: null as unknown as PublicKey },
+      connection: {},
+    };
+
+    mockClients.push(
+      timeoutClient,
+      timeoutClient,
+      timeoutClient,
+      timeoutClient
+    );
+
+    await expect(getOISStakingInfo(WALLET_ADDRESS)).rejects.toThrow(
+      "RPC timeout: Unable to discover staking account. Please try again later."
+    );
+  });
+
   // ── Return shape ────────────────────────────────────────────────────────────
 
   it("returns the auto-discovered staking address as a base58 string", async () => {

--- a/tests/walletRefresh.test.ts
+++ b/tests/walletRefresh.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+
+import type { WalletInfo } from "@/types/pythTypes";
+import { refreshWalletsSequentially } from "@/lib/wallet-refresh";
+
+const baseWallet = (id: string, totalStakedPyth: number): WalletInfo => ({
+  id,
+  name: `Wallet ${id}`,
+  address: `address-${id}`,
+  stakingAddress: `staking-${id}`,
+  stakingInfo: {
+    StakeForEachPublisher: [],
+    totalStakedPyth,
+    claimableRewards: totalStakedPyth / 10,
+    generalStats: {
+      totalGovernance: 1,
+      totalStaked: 2,
+      rewardsDistributed: 3,
+    },
+  },
+});
+
+describe("refreshWalletsSequentially", () => {
+  it("updates wallets one at a time and emits progressive snapshots", async () => {
+    const wallets = [baseWallet("1", 10), baseWallet("2", 20)];
+    const callOrder: string[] = [];
+    const updates: WalletInfo[][] = [];
+
+    const refreshWallet = vi.fn(async (wallet: WalletInfo) => {
+      callOrder.push(`start-${wallet.id}`);
+      await Promise.resolve();
+      callOrder.push(`end-${wallet.id}`);
+
+      return {
+        info: {
+          ...wallet.stakingInfo!,
+          totalStakedPyth: wallet.stakingInfo!.totalStakedPyth + 100,
+        },
+        stakingAddress: wallet.stakingAddress,
+      };
+    });
+
+    const result = await refreshWalletsSequentially(
+      wallets,
+      refreshWallet,
+      (nextWallets) => {
+        updates.push(nextWallets);
+      }
+    );
+
+    expect(callOrder).toEqual(["start-1", "end-1", "start-2", "end-2"]);
+    expect(updates).toHaveLength(2);
+    expect(updates[0][0].stakingInfo?.totalStakedPyth).toBe(110);
+    expect(updates[0][1].stakingInfo?.totalStakedPyth).toBe(20);
+    expect(updates[1][1].stakingInfo?.totalStakedPyth).toBe(120);
+    expect(result[0].stakingInfo?.totalStakedPyth).toBe(110);
+    expect(result[1].stakingInfo?.totalStakedPyth).toBe(120);
+  });
+
+  it("keeps the cached wallet data when a refresh fails", async () => {
+    const wallets = [baseWallet("1", 10), baseWallet("2", 20)];
+    const updates: WalletInfo[][] = [];
+
+    const refreshWallet = vi.fn(async (wallet: WalletInfo) => {
+      if (wallet.id === "1") {
+        throw new Error("RPC failed");
+      }
+
+      return {
+        info: {
+          ...wallet.stakingInfo!,
+          totalStakedPyth: 999,
+        },
+        stakingAddress: wallet.stakingAddress,
+      };
+    });
+
+    const result = await refreshWalletsSequentially(
+      wallets,
+      refreshWallet,
+      (nextWallets) => {
+        updates.push(nextWallets);
+      }
+    );
+
+    expect(result[0].stakingInfo?.totalStakedPyth).toBe(10);
+    expect(result[1].stakingInfo?.totalStakedPyth).toBe(999);
+    expect(updates.at(-1)?.[0].stakingInfo?.totalStakedPyth).toBe(10);
+    expect(updates.at(-1)?.[1].stakingInfo?.totalStakedPyth).toBe(999);
+  });
+});

--- a/tests/walletRefresh.test.ts
+++ b/tests/walletRefresh.test.ts
@@ -53,11 +53,13 @@ describe("refreshWalletsSequentially", () => {
     expect(updates[0][0].stakingInfo?.totalStakedPyth).toBe(110);
     expect(updates[0][1].stakingInfo?.totalStakedPyth).toBe(20);
     expect(updates[1][1].stakingInfo?.totalStakedPyth).toBe(120);
-    expect(result[0].stakingInfo?.totalStakedPyth).toBe(110);
-    expect(result[1].stakingInfo?.totalStakedPyth).toBe(120);
+    expect(result.wallets[0].stakingInfo?.totalStakedPyth).toBe(110);
+    expect(result.wallets[1].stakingInfo?.totalStakedPyth).toBe(120);
+    expect(result.hadErrors).toBe(false);
+    expect(result.errorMessage).toBeNull();
   });
 
-  it("keeps the cached wallet data when a refresh fails", async () => {
+  it("keeps the cached wallet data and reports an error when a refresh fails", async () => {
     const wallets = [baseWallet("1", 10), baseWallet("2", 20)];
     const updates: WalletInfo[][] = [];
 
@@ -83,9 +85,13 @@ describe("refreshWalletsSequentially", () => {
       }
     );
 
-    expect(result[0].stakingInfo?.totalStakedPyth).toBe(10);
-    expect(result[1].stakingInfo?.totalStakedPyth).toBe(999);
+    expect(result.wallets[0].stakingInfo?.totalStakedPyth).toBe(10);
+    expect(result.wallets[1].stakingInfo?.totalStakedPyth).toBe(999);
     expect(updates.at(-1)?.[0].stakingInfo?.totalStakedPyth).toBe(10);
     expect(updates.at(-1)?.[1].stakingInfo?.totalStakedPyth).toBe(999);
+    expect(result.hadErrors).toBe(true);
+    expect(result.errorMessage).toBe(
+      "Some wallet balances could not be refreshed. Try again later."
+    );
   });
 });


### PR DESCRIPTION
## Summary
- remove the manual staking account input requirement from wallet add and improve staking account discovery error handling
- reduce reload RPC pressure by refreshing wallet balances sequentially with fallback behavior and cached data shown immediately
- move wallet refresh status into the shared header with animated refresh feedback and visible error messaging
- surface exact sanitized add-wallet errors in the wallet toast
- add wallet refresh helpers/tests and bump the app version to `0.3.3`

## Testing
- `pnpm vitest run tests/pythActions.test.ts tests/walletRefresh.test.ts`
- `pnpm vitest run tests/priceActions.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic staking address discovery—users no longer need to manually enter staking addresses.
  * Real-time wallet refresh status indicators showing "Refreshing wallet balances..." with completion feedback in the header.
  * Background wallet balance synchronization with error tracking.

* **Tests**
  * Added comprehensive test coverage for price data retrieval, staking operations, and wallet refresh workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->